### PR TITLE
updated to cqf-ruler-preloaded 0.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   inferno:
     build:
@@ -9,6 +9,10 @@ services:
       - "4567:4567"
     depends_on:
       - validator_service
+  cqf_ruler:
+    image: tacoma/cqf-ruler-preloaded:0.5.0.no-vs
+    ports:
+      - "8080:8080"
   validator_service:
     image: infernocommunity/fhir-validator-service:latest
     # Update this path to match your directory structure


### PR DESCRIPTION
# Summary
Added cqf-ruler-preloaded 0.5.0 to docker-compose. Also updated Measure bundles in cqf-ruler-preloaded docker image 
## New behavior
- when started using docker-compose, cqf-ruler-preloaded will also start
- the docker image for tacoma/cqf-ruler-preloaded:0.5.0.no-vs now contains updated libraries, measures, and measureReports
## Code changes
Added configuration to run cqf-ruler-preloaded in the docker-compose of deqm-test-kit
# Testing guidance
from the base directory of the branch, run
- `docker-compose build`
- `docker-compose pull`
- `docker-compose up`
now, navigate to localhost:4567 in your browser. 
- Click on DEQM Measure Operations Test Suite and ensure it highlights in orange
- Click Start Testing
- Click the play button next to CapabilityStatements. This should prompt you to enter a URL
- Enter http://cqf_ruler:8080/cqf-ruler-r4/fhir into the url field
- Click submit
- The test should pass and display a check mark as well as a 200 response code

Additionally, please verify that the measures, measure reports, and libraries stored in tacoma/cqf-ruler-preloaded:0.5.0.no-vs docker image are up to date with the fhir401 versions of EXM104, EXM105, EXM111, EXM125.9.0.000, EXM130, and EXM506 from the connectathon repository. This can be accomplished by pulling the docker image using
- `docker pull tacoma/cqf-ruler-preloaded:0.5.0.no-vs`
- `docker run -p 8080:8080 -d tacoma/cqf-ruler-preloaded:0.5.0.no-vs`
Then navigate to localhost:8080/cqf-ruler-r4 in your browser
Select libraries from the left-hand bar and click search. This should bring up all libraries stored on the server. You can click on each library here to make sure it contains all the correct info. Once done verifying the libraries, repeat for the measures and measure reports.