### PR TITLE
Measure availability group

### DIFF
--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'deqm_test_kit/patient_group'
+require_relative 'deqm_test_kit/measure_availability'
 
 module DEQMTestKit
   class Suite < Inferno::TestSuite
@@ -39,5 +40,6 @@ module DEQMTestKit
     # Tests and TestGroups can be written in separate files and then included
     # using their id
     group from: :patient_group
+    group from: :measure_availability
   end
 end

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -30,10 +30,7 @@ module DEQMTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         measure_bundle = JSON.parse(response[:body])
-        
-
         assert measure_bundle["total"].positive?, "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
-        assert false, "Measure bundle logged #{measure_bundle.to_s}"
       end
     end
   end

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -1,0 +1,40 @@
+module DEQMTestKit
+  class MeasureAvailability < Inferno::TestGroup
+    id 'measure_availability'
+    title 'Measure Availability'
+    description 'Ensure selected measures are available on the fhir server'
+
+    fhir_client do
+      url :url
+    end
+
+    MEASURES = ['EXM130|7.3.000','EXM125|7.3.000']
+
+    test do
+      title 'Measure can be found'
+      id 'measure-availability-01'
+      description 'Selected measure with matching id is available on the server and a valid json object'
+      makes_request :measure_search
+
+      run do
+        # Look for matching measure from cqf-ruler datastore by resource id
+        # TODO: actually pull measure from user input drop down (populated from embedded client)
+        measure_to_test = MEASURES[0]
+        measure_identifier, measure_version = measure_to_test.split('|')
+
+        # @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
+
+        # Search system for measure by identifier and version
+        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        measure_bundle = JSON.parse(response[:body])
+        
+
+        assert measure_bundle["total"].positive?, "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
+        assert false, "Measure bundle logged #{measure_bundle.to_s}"
+      end
+    end
+  end
+end

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module DEQMTestKit
+  # MeasureAvailability test group ensures selected measures are available on the fhir server
   class MeasureAvailability < Inferno::TestGroup
     id 'measure_availability'
     title 'Measure Availability'
@@ -8,7 +11,7 @@ module DEQMTestKit
       url :url
     end
 
-    MEASURES = ['EXM130|7.3.000','EXM125|7.3.000']
+    MEASURES = ['EXM130|7.3.000', 'EXM125|7.3.000'].freeze
 
     test do
       title 'Measure can be found'
@@ -22,15 +25,14 @@ module DEQMTestKit
         measure_to_test = MEASURES[0]
         measure_identifier, measure_version = measure_to_test.split('|')
 
-        # @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
-
         # Search system for measure by identifier and version
         fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         measure_bundle = JSON.parse(response[:body])
-        assert measure_bundle["total"].positive?, "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
+        assert measure_bundle['total'].positive?,
+               "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
       end
     end
   end

--- a/lib/deqm_test_kit/patient_group.rb
+++ b/lib/deqm_test_kit/patient_group.rb
@@ -2,7 +2,7 @@
 
 module DEQMTestKit
   class PatientGroup < Inferno::TestGroup
-    title 'Patient  Tests'
+    title 'Patient Tests'
     description 'Verify that the server makes Patient resources available'
     id :patient_group
 

--- a/spec/deqm_test_kit/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/measure_availability_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe DEQMTestKit::MeasureAvailability do
+    let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+    let(:group) { suite.groups[2] }
+    let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
+    let(:url) { 'http://example.com/fhir' }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+  
+    def run(runnable, inputs = {})
+      test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+      test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+      Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable, inputs)
+      Inferno::Repositories::TestRuns.new.results_for_test_run(test_run.id)
+    end
+  
+    describe 'measure search test' do
+      let(:test) { group.tests.first }
+      let(:measure_name) { 'EXM130' }
+      let(:measure_version) { '7.3.000' }
+  
+      it 'passes if a Measure was received' do
+        resource = FHIR::Bundle.new(total: 1)
+        
+        stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+          .to_return(status: 200, body: resource.to_json)
+  
+        # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
+        result = run(test, url: url).first
+  
+        expect(result.result).to eq('pass')
+      end
+  
+      it 'fails if a 200 is not received' do
+        resource = FHIR::Bundle.new(total: 1)
+        stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+          .to_return(status: 201, body: resource.to_json)
+  
+        result = run(test, url: url).first
+  
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match(/200/)
+      end
+  
+      it 'fails if a Measure is not received in the Bundle' do
+        resource = FHIR::Bundle.new(total: 0)
+        stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+          .to_return(status: 200, body: resource.to_json)
+  
+        result = run(test, url: url).first
+  
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match(/measure/)
+      end
+    end
+  end
+  

--- a/spec/deqm_test_kit/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/measure_availability_spec.rb
@@ -1,57 +1,56 @@
 # frozen_string_literal: true
 
 RSpec.describe DEQMTestKit::MeasureAvailability do
-    let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-    let(:group) { suite.groups[2] }
-    let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
-    let(:url) { 'http://example.com/fhir' }
-    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-  
-    def run(runnable, inputs = {})
-      test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-      test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-      Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable, inputs)
-      Inferno::Repositories::TestRuns.new.results_for_test_run(test_run.id)
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+  let(:group) { suite.groups[2] }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable, inputs)
+    Inferno::Repositories::TestRuns.new.results_for_test_run(test_run.id)
+  end
+
+  describe 'measure search test' do
+    let(:test) { group.tests.first }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+
+    it 'passes if a Measure was received' do
+      resource = FHIR::Bundle.new(total: 1)
+
+      stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: resource.to_json)
+
+      # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
+      result = run(test, url: url).first
+
+      expect(result.result).to eq('pass')
     end
-  
-    describe 'measure search test' do
-      let(:test) { group.tests.first }
-      let(:measure_name) { 'EXM130' }
-      let(:measure_version) { '7.3.000' }
-  
-      it 'passes if a Measure was received' do
-        resource = FHIR::Bundle.new(total: 1)
-        
-        stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
-          .to_return(status: 200, body: resource.to_json)
-  
-        # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
-        result = run(test, url: url).first
-  
-        expect(result.result).to eq('pass')
-      end
-  
-      it 'fails if a 200 is not received' do
-        resource = FHIR::Bundle.new(total: 1)
-        stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
-          .to_return(status: 201, body: resource.to_json)
-  
-        result = run(test, url: url).first
-  
-        expect(result.result).to eq('fail')
-        expect(result.result_message).to match(/200/)
-      end
-  
-      it 'fails if a Measure is not received in the Bundle' do
-        resource = FHIR::Bundle.new(total: 0)
-        stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
-          .to_return(status: 200, body: resource.to_json)
-  
-        result = run(test, url: url).first
-  
-        expect(result.result).to eq('fail')
-        expect(result.result_message).to match(/measure/)
-      end
+
+    it 'fails if a 200 is not received' do
+      resource = FHIR::Bundle.new(total: 1)
+      stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 201, body: resource.to_json)
+
+      result = run(test, url: url).first
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
+    end
+
+    it 'fails if a Measure is not received in the Bundle' do
+      resource = FHIR::Bundle.new(total: 0)
+      stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: resource.to_json)
+
+      result = run(test, url: url).first
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/measure/)
     end
   end
-  
+end


### PR DESCRIPTION
# Summary
Creates the measure availability test group in the deqm test kit. Uses a constant of available measures, which should in the future be pulled from the embedded cqf_ruler instance to populate a drop down (to be added as an inferno core UI element in the future).
## New behavior
deqm test kit provides includes test group "Measure Availability" which may be selected and tested with a cqf ruler instance as the client. Preloaded cqf_ruler should pass. A server without EXM130 would fail.
## Code changes
Adds `measure_availability.rb` test group and `measure_availability_spec.rb` to test pass/fail expectations. Updates the main deqm test kit file to use the new measure availability test group.
# Testing guidance
This can be tested by running the test kit (`docker-compose build`, `docker-compose pull`, `docker-compose up`), and using a cqf ruler instance (`docker run -d -p 3002:8080 tacoma/cqf-ruler-preloaded:0.5.0.no-vs`) or cqf_ruler embedded (as long as it starts properly on `docker-compose up`). The cqf-ruler url looks something like `http://{ip}:{port}/cqf-ruler-r4/fhir` and this is used as the url input when running the test through the inferno UI, which is accessed at `http://{ip}:4567`.
