### PR TITLE
Data req suite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,15 +149,15 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     netrc (0.11.0)
     nio4r (2.5.7)
-    nokogiri (1.11.7-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.7-x86_64-linux)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -237,6 +237,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -2,6 +2,7 @@
 
 require_relative 'deqm_test_kit/patient_group'
 require_relative 'deqm_test_kit/measure_availability'
+require_relative 'deqm_test_kit/data_requirements'
 
 module DEQMTestKit
   class Suite < Inferno::TestSuite
@@ -41,5 +42,6 @@ module DEQMTestKit
     # using their id
     group from: :patient_group
     group from: :measure_availability
+    group from: :data_requirements
   end
 end

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -1,73 +1,81 @@
+# frozen_string_literal: true
+
 module DEQMTestKit
+  # GET [base]/Measure/CMS146/$data-requirements?periodStart=2014&periodEnd=2014
+  class DataRequirements < Inferno::TestGroup
+    id 'data_requirements'
+    title 'Data Requirements'
+    description 'Ensure fhir server can respond to the $data-requirements request'
 
-    #GET [base]/Measure/CMS146/$data-requirements?periodStart=2014&periodEnd=2014
-    class DataRequirements < Inferno::TestGroup
-      id 'data_requirements'
-      title 'Data Requirements'
-      description 'Ensure fhir server can respond to the $data-requirements request'
-  
-      fhir_client do
-        url :url
-      end
+    fhir_client do
+      url :url
+    end
 
-      fhir_client :embedded_client do
-        url 'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
-      end
-  
-      test do
-        title 'Check data requirements against expected return'
-        id 'data-requirements-01'
-        description 'Data requirements on the fhir test server match the data requirements of our embedded client'
-        makes_request :data_requirements
+    fhir_client :embedded_client do
+      url 'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
+    end
 
-        PARAMS = {
-            resourceType: "Parameters",
-            parameter:[{
-                periodStart: '2019-01-01',
-                periodEnd: '2019-12-31'
-              
-            }]
-      }
-        run do
-          # Look for matching measure from cqf-ruler datastore by resource id
-          # TODO: actually pull measure from user input drop down (populated from embedded client)
-          measure_to_test = 'EXM130|7.3.000'
-          measure_identifier, measure_version = measure_to_test.split('|')
-    
-          # Search system for measure by identifier and version
-          fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
-          assert_response_status(200)
-          assert_resource_type(:bundle)
-          assert_valid_json(response[:body])
-          measure_bundle = JSON.parse(response[:body])
-          assert measure_bundle["total"].positive?, "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
-          
-          id = measure_bundle["entry"][0]["resource"]["id"]
+    PARAMS = {
+      resourceType: 'Parameters',
+      parameter: [{
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31'
 
-          # Run our data requirements operation on the test client server
-          fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, name: :data_requirements)
-          library = JSON.parse(response[:body])
-          actual_dr = library["dataRequirement"]
-          assert_response_status(200)
-          assert_resource_type(:library)
-          assert_valid_json(response[:body])
-          
-          # Search embedded cqf-ruler instance by identifier and version
-          fhir_search(:measure, client: :embedded_client, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
-          measure_bundle = JSON.parse(response[:body])
-          
-          id = measure_bundle["entry"][0]["resource"]["id"]
-          
-          # Run data requirements operation on embedded cqf-ruler instance
-          fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, client: :embedded_client, name: :data_requirements)
-          expected_library = JSON.parse(response[:body])
-          expected_dr = expected_library["dataRequirement"]
+      }]
+    }.freeze
 
-          # Ensure both data requirements results libraries are identical
-          assert((expected_dr - actual_dr).blank?, "Client data-requirements is missing expected data requirements for measure #{id}")
-          assert((actual_dr - expected_dr).blank?, "Client data-requirements contains unexpected data requirements for measure #{id}")
+    # rubocop:disable Metrics/BlockLength
+    test do
+      title 'Check data requirements against expected return'
+      id 'data-requirements-01'
+      description 'Data requirements on the fhir test server match the data requirements of our embedded client'
+      makes_request :data_requirements
 
-        end
+      run do
+        # Look for matching measure from cqf-ruler datastore by resource id
+        # TODO: actually pull measure from user input drop down (populated from embedded client)
+        measure_to_test = 'EXM130|7.3.000'
+        measure_identifier, measure_version = measure_to_test.split('|')
+
+        # Search system for measure by identifier and version
+        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        measure_bundle = JSON.parse(response[:body])
+        assert measure_bundle['total'].positive?,
+               "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
+
+        id = measure_bundle['entry'][0]['resource']['id']
+
+        # Run our data requirements operation on the test client server
+        fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, name: :data_requirements)
+        library = JSON.parse(response[:body])
+        actual_dr = library['dataRequirement']
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+
+        # Search embedded cqf-ruler instance by identifier and version
+        fhir_search(:measure, client: :embedded_client,
+                              params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+        measure_bundle = JSON.parse(response[:body])
+
+        id = measure_bundle['entry'][0]['resource']['id']
+
+        # Run data requirements operation on embedded cqf-ruler instance
+        fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, client: :embedded_client,
+                                                           name: :data_requirements)
+        expected_library = JSON.parse(response[:body])
+        expected_dr = expected_library['dataRequirement']
+
+        # Ensure both data requirements results libraries are identical
+        assert((expected_dr - actual_dr).blank?,
+               "Client data-requirements is missing expected data requirements for measure #{id}")
+        assert((actual_dr - expected_dr).blank?,
+               "Client data-requirements contains unexpected data requirements for measure #{id}")
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
+end

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -33,7 +33,8 @@ module DEQMTestKit
 
       run do
         # Look for matching measure from cqf-ruler datastore by resource id
-        # TODO: actually pull measure from user input drop down (populated from embedded client)
+        # TODO: actually pull measure from user input drop down (populated from embedded client),
+        # whichever was selected from measure availability group
         measure_to_test = 'EXM130|7.3.000'
         measure_identifier, measure_version = measure_to_test.split('|')
 
@@ -46,34 +47,34 @@ module DEQMTestKit
         assert measure_bundle['total'].positive?,
                "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
 
-        id = measure_bundle['entry'][0]['resource']['id']
+        test_client_id = measure_bundle['entry'][0]['resource']['id']
 
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, name: :data_requirements)
-        library = JSON.parse(response[:body])
-        actual_dr = library['dataRequirement']
+        fhir_operation("Measure/#{test_client_id}/$data-requirements", body: PARAMS, name: :data_requirements)
         assert_response_status(200)
         assert_resource_type(:library)
         assert_valid_json(response[:body])
+
+        library = JSON.parse(response[:body])
+        actual_dr = library['dataRequirement']
 
         # Search embedded cqf-ruler instance by identifier and version
         fhir_search(:measure, client: :embedded_client,
                               params: { name: measure_identifier, version: measure_version }, name: :measure_search)
         measure_bundle = JSON.parse(response[:body])
 
-        id = measure_bundle['entry'][0]['resource']['id']
+        embedded_client_id = measure_bundle['entry'][0]['resource']['id']
 
         # Run data requirements operation on embedded cqf-ruler instance
-        fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, client: :embedded_client,
-                                                           name: :data_requirements)
+        fhir_operation("Measure/#{embedded_client_id}/$data-requirements", body: PARAMS, client: :embedded_client)
         expected_library = JSON.parse(response[:body])
         expected_dr = expected_library['dataRequirement']
 
         # Ensure both data requirements results libraries are identical
         assert((expected_dr - actual_dr).blank?,
-               "Client data-requirements is missing expected data requirements for measure #{id}")
+               "Client data-requirements is missing expected data requirements for measure #{test_client_id}")
         assert((actual_dr - expected_dr).blank?,
-               "Client data-requirements contains unexpected data requirements for measure #{id}")
+               "Client data-requirements contains unexpected data requirements for measure #{test_client_id}")
       end
     end
   end

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -9,29 +9,59 @@ module DEQMTestKit
       fhir_client do
         url :url
       end
+
+      fhir_client :embedded_client do
+        url 'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
+      end
   
       test do
         title 'Check data requirements against expected return'
         id 'data-requirements-01'
         description 'Data requirements on the fhir test server match the data requirements of our embedded client'
         makes_request :data_requirements
-  
+
+        PARAMS = {
+            resourceType: "Parameters",
+            parameter:[{
+                periodStart: '2019-01-01',
+                periodEnd: '2019-12-31'
+              
+            }]
+      }
         run do
           # Look for matching measure from cqf-ruler datastore by resource id
           # TODO: actually pull measure from user input drop down (populated from embedded client)
           measure_to_test = 'EXM130|7.3.000'
           measure_identifier, measure_version = measure_to_test.split('|')
-  
-          # @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
-  
+    
           # Search system for measure by identifier and version
           fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
-          measure_bundle = JSON.parse(response[:body])
-          id = measure_bundle.entry[0].resource.id;
-          fhir_operation("Measure/#{id}/$data-requirements", name: :data_requirements)
           assert_response_status(200)
-          assert_resource_type(:measure)
+          assert_resource_type(:bundle)
           assert_valid_json(response[:body])
+          measure_bundle = JSON.parse(response[:body])
+          assert measure_bundle["total"].positive?, "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
+          
+          id = measure_bundle["entry"][0]["resource"]["id"]
+
+          fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, name: :data_requirements)
+          library = JSON.parse(response[:body])
+          actual_dr = library["dataRequirement"]
+          assert_response_status(200)
+          assert_resource_type(:library)
+          assert_valid_json(response[:body])
+
+          fhir_search(:measure, client: :embedded_client, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+          measure_bundle = JSON.parse(response[:body])
+          
+          id = measure_bundle["entry"][0]["resource"]["id"]
+          
+          fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, client: :embedded_client, name: :data_requirements)
+          expected_library = JSON.parse(response[:body])
+          expected_dr = expected_library["dataRequirement"]
+
+          assert((expected_dr - actual_dr).blank?, "Client data-requirements is missing expected data requirements for measure #{id}")
+          assert((actual_dr - expected_dr).blank?, "Client data-requirements contains unexpected data requirements for measure #{id}")
 
         end
       end

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -25,7 +25,10 @@ module DEQMTestKit
           # @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
   
           # Search system for measure by identifier and version
-          fhir_read(:measure, "measure-EXM130-7.3.000", name: :data_requirements)
+          fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+          measure_bundle = JSON.parse(response[:body])
+          id = measure_bundle.entry[0].resource.id;
+          fhir_operation("Measure/#{id}/$data-requirements", name: :data_requirements)
           assert_response_status(200)
           assert_resource_type(:measure)
           assert_valid_json(response[:body])

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -44,22 +44,26 @@ module DEQMTestKit
           
           id = measure_bundle["entry"][0]["resource"]["id"]
 
+          # Run our data requirements operation on the test client server
           fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, name: :data_requirements)
           library = JSON.parse(response[:body])
           actual_dr = library["dataRequirement"]
           assert_response_status(200)
           assert_resource_type(:library)
           assert_valid_json(response[:body])
-
+          
+          # Search embedded cqf-ruler instance by identifier and version
           fhir_search(:measure, client: :embedded_client, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
           measure_bundle = JSON.parse(response[:body])
           
           id = measure_bundle["entry"][0]["resource"]["id"]
           
+          # Run data requirements operation on embedded cqf-ruler instance
           fhir_operation("Measure/#{id}/$data-requirements", body: PARAMS, client: :embedded_client, name: :data_requirements)
           expected_library = JSON.parse(response[:body])
           expected_dr = expected_library["dataRequirement"]
 
+          # Ensure both data requirements results libraries are identical
           assert((expected_dr - actual_dr).blank?, "Client data-requirements is missing expected data requirements for measure #{id}")
           assert((actual_dr - expected_dr).blank?, "Client data-requirements contains unexpected data requirements for measure #{id}")
 

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -1,0 +1,36 @@
+module DEQMTestKit
+
+    #GET [base]/Measure/CMS146/$data-requirements?periodStart=2014&periodEnd=2014
+    class DataRequirements < Inferno::TestGroup
+      id 'data_requirements'
+      title 'Data Requirements'
+      description 'Ensure fhir server can respond to the $data-requirements request'
+  
+      fhir_client do
+        url :url
+      end
+  
+      test do
+        title 'Check data requirements against expected return'
+        id 'data-requirements-01'
+        description 'Data requirements on the fhir test server match the data requirements of our embedded client'
+        makes_request :data_requirements
+  
+        run do
+          # Look for matching measure from cqf-ruler datastore by resource id
+          # TODO: actually pull measure from user input drop down (populated from embedded client)
+          measure_to_test = 'EXM130|7.3.000'
+          measure_identifier, measure_version = measure_to_test.split('|')
+  
+          # @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
+  
+          # Search system for measure by identifier and version
+          fhir_read(:measure, "measure-EXM130-7.3.000", name: :data_requirements)
+          assert_response_status(200)
+          assert_resource_type(:measure)
+          assert_valid_json(response[:body])
+
+        end
+      end
+    end
+  end

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe DEQMTestKit::DataRequirements do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+  let(:group) { suite.groups[3] }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
+  let(:url) { 'http://example.com/fhir' }
+  let(:embedded_client) do
+    'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
+  end
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable, inputs)
+    Inferno::Repositories::TestRuns.new.results_for_test_run(test_run.id)
+  end
+
+  describe 'data requirements test' do
+    let(:test) { group.tests.first }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:test_id) { 'test_id' }
+
+    it 'passes if a Library was received' do
+      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      test_library_response = FHIR::Library.new(dataRequirement: [{ type: 'Condition' }])
+
+      stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: test_measure_response.to_json)
+
+      stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: test_measure_response.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      stub_request(:post, "#{embedded_client}/Measure/#{test_id}/$data-requirements")
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
+      result = run(test, url: url).first
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not received' do
+      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      test_library_response = FHIR::Library.new
+
+      stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: test_measure_response.to_json)
+
+      stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: test_measure_response.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
+        .to_return(status: 201, body: test_library_response.to_json)
+
+      stub_request(:post, "#{embedded_client}/Measure/#{test_id}/$data-requirements")
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      result = run(test, url: url).first
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
+    end
+
+    it 'fails if a Library is not received' do
+      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      test_not_library_response = FHIR::Bundle.new
+
+      stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: test_measure_response.to_json)
+
+      stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
+        .to_return(status: 200, body: test_measure_response.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
+        .to_return(status: 200, body: test_not_library_response.to_json)
+
+      stub_request(:post, "#{embedded_client}/Measure/#{test_id}/$data-requirements")
+        .to_return(status: 200, body: test_not_library_response.to_json)
+
+      result = run(test, url: url).first
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match('Bad resource type received: expected Library, but received Bundle')
+    end
+  end
+end

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
   let(:group) { suite.groups[3] }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   let(:url) { 'http://example.com/fhir' }
+  # ensure this url matches url in embedded_client in data_requirements.rb
   let(:embedded_client) do
     'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
   end
@@ -54,6 +55,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
+      # external client returns 201 instead of 200
       stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
         .to_return(status: 201, body: test_library_response.to_json)
 
@@ -68,6 +70,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
     it 'fails if a Library is not received' do
       test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      # returns a bundle not a library
       test_not_library_response = FHIR::Bundle.new
 
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")


### PR DESCRIPTION
# Summary
deqm-test-kit can now test data-requirements operations of a test client server against the data-requirements output of the embedded cqf-ruler instance
## New behavior
There is a new test category: "Data Requirements" in the DEQM Measure Operations Test Suite when running the deqm-test-kit using docker=compose commands which will run a data-requirements operation on a hard-coded (for now) measure on both the passed in test client and the embedded cqf-ruler instance. The test will pass if the results are retrieved from both sources and match. 
## Code changes
- Added a new class DataRequirements
- Added code to deqm-test-kit.rb to include DataRequirements checks in the test suite
- Added unit tests for DataRequirements test module
# Testing guidance
1. Start a Docker Daemon running in the background (I did this by opening Docker desktop)
2. run `docker-compose build`
3. run `docker-compose pull`
4. run `docker-compose up`
5. navigate to [http://localhost:4567](http://localhost:4567)
6. select DEQM Measure Operations Test Suite and click "Start Testing"
7. Wait for cqf_ruler_to finish start-up. You should see `Server:main: Started @ {timestamp}` logged to the terminal
8. Click the play button by Data Requirements
9. After a moment, this test should pass and display a green checkmark

In addition to testing functionality, please examine the code in deqm_test_kit/data_requirements.rb closely. I have not worked with Ruby or Inferno before and had limited testing options, so any input here would be greatly appreciated. A couple of notes before diving in:

1. The fhir_search function is repeating code from the measure_availability test module. The ultimate goal here is to force the tests to be run in sequence and save the measure id retrieved in the measure_availability test in a place where the data_requirements test can access it. For the time being, we don't know how to do this. This may become a subsequent task
2. The Measure to test is currently hard coded. Eventually we will want the user to be able to select which measure to use for the data_requirements operation via a dropdown in the front-end. I believe we are waiting for the Inferno team to build this functionality
3. The embedded cqf_ruler URL is currently hard-coded as well as a string. Ideally we want to replace this with some symbol that stores the URL. I am unsure how to do this for now, but happy to work through it with a reviewer/make changes if someone knows how to accomplish this.
