### PR TITLE
Submit data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,23 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
+  deqm_test_server:
+    depends_on:
+      - mongo
+    image: tacoma/deqm-test-server:connectathon
+    environment:
+      DB_HOST: mongo
+      DB_PORT: 27017
+      DB_NAME: deqm-test-server-dev
+    ports:
+      - "3000:3000"
+    command: npm start
+  mongo:
+    image: mongo:4.4.4
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  mongo_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   deqm_test_server:
     depends_on:
       - mongo
-    image: tacoma/deqm-test-server:connectathon
+    image: tacoma/deqm-test-server:latest
     environment:
       DB_HOST: mongo
       DB_PORT: 27017

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -3,6 +3,7 @@
 require_relative 'deqm_test_kit/patient_group'
 require_relative 'deqm_test_kit/measure_availability'
 require_relative 'deqm_test_kit/data_requirements'
+require_relative 'deqm_test_kit/submit_data'
 
 module DEQMTestKit
   class Suite < Inferno::TestSuite
@@ -43,5 +44,6 @@ module DEQMTestKit
     # group from: :patient_group
     group from: :measure_availability
     group from: :data_requirements
+    group from: :submit_data
   end
 end

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -40,7 +40,7 @@ module DEQMTestKit
 
     # Tests and TestGroups can be written in separate files and then included
     # using their id
-    group from: :patient_group
+    # group from: :patient_group
     group from: :measure_availability
     group from: :data_requirements
   end

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -52,26 +52,27 @@ module DEQMTestKit
         assert_resource_type(:library)
         assert_valid_json(response[:body])
 
-        library = JSON.parse(response[:body])
-        actual_dr = library['dataRequirement']
+        actual_dr = resource.dataRequirement
 
         actual_dr_strings = get_dr_comparison_list actual_dr
 
         # Search embedded cqf-ruler instance by identifier and version
         fhir_search(:measure, client: :embedded_client,
                               params: { name: measure_identifier, version: measure_version }, name: :measure_search)
-        measure_bundle = JSON.parse(response[:body])
-
-        embedded_client_id = measure_bundle['entry'][0]['resource']['id']
+        embedded_client_id = resource.entry[0].resource.id
 
         # Run data requirements operation on embedded cqf-ruler instance
         fhir_operation("Measure/#{embedded_client_id}/$data-requirements", body: PARAMS, client: :embedded_client)
-        expected_library = JSON.parse(response[:body])
-        expected_dr = expected_library['dataRequirement']
+        expected_dr = resource.dataRequirement
 
         expected_dr_strings = get_dr_comparison_list expected_dr
 
         diff = expected_dr_strings - actual_dr_strings
+
+        # still output queries even if different from expected.
+        # TODO: output queries only if pass once they align with cqf-ruler
+        queries = get_data_requirements_queries(actual_dr)
+        output queries_json: queries.to_json
 
         # Ensure both data requirements results libraries are identical
         assert(diff.blank?,
@@ -80,8 +81,6 @@ module DEQMTestKit
         diff = actual_dr_strings - expected_dr_strings
         assert(diff.blank?,
                "Client data-requirements contains unexpected data requirements for measure #{measure_id}: #{diff}")
-        queries = get_data_requirements_queries(actual_dr)
-        output queries_json: queries.to_json
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -31,10 +31,9 @@ module DEQMTestKit
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
-        measure_bundle = JSON.parse(response[:body])
-        assert measure_bundle['total'].positive?,
+        assert resource.total.positive?,
                "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
-        output measure_id: measure_bundle['entry'][0]['resource']['id']
+        output measure_id: resource.entry[0].resource.id
       end
     end
   end

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -18,6 +18,7 @@ module DEQMTestKit
       id 'measure-availability-01'
       description 'Selected measure with matching id is available on the server and a valid json object'
       makes_request :measure_search
+      output :measure_id
 
       run do
         # Look for matching measure from cqf-ruler datastore by resource id
@@ -33,6 +34,7 @@ module DEQMTestKit
         measure_bundle = JSON.parse(response[:body])
         assert measure_bundle['total'].positive?,
                "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
+        output measure_id: measure_bundle['entry'][0]['resource']['id']
       end
     end
   end

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'byebug'
 require 'securerandom'
 
 module DEQMTestKit

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'byebug'
+require 'securerandom'
+
+module DEQMTestKit
+  # Perform submit data operation on test client
+  class SubmitData < Inferno::TestGroup
+    id 'submit_data'
+    title 'Submit Data'
+    description 'Ensure fhir server can receive data via the $submit-data operation'
+
+    fhir_client do
+      url :url
+    end
+
+    fhir_client :embedded_client do
+      url 'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
+    end
+
+    # rubocop:disable Metrics/BlockLength
+    test do
+      title 'Submit Data valid submission'
+      id 'submit-data-01'
+      description 'Submit resources relevant to a measure, and then verify they persist on the server.'
+      makes_request :submit_data
+      input :queries_json
+      input :measure_id
+
+      run do
+        # get measure from client
+        assert(measure_id,
+               'No measure selected. You must run the Measure Availability test group prior to running the Submit Data test group.')
+        fhir_read(:measure, measure_id)
+        assert_valid_json(response[:body])
+        measure = JSON.parse(response[:body])
+
+        assert_valid_json(queries_json, 'Valid json queries must be passed from the Data Requirements test group') # for safety
+        queries = JSON.parse(queries_json)
+        # If we have no queries, get all of these types
+        if queries.empty?
+          queries = [
+            { 'endpoint' => 'Patient', 'params' => {} },
+            { 'endpoint' => 'Encounter', 'params' => {} },
+            { 'endpoint' => 'Condition', 'params' => {} },
+            { 'endpoint' => 'Procedure', 'params' => {} },
+            { 'endpoint' => 'Observation', 'params' => {} }
+          ]
+        end
+        # Call the $updateCodeSystems workaround on embedded cqf-ruler so code:in queries work
+        fhir_operation('$updateCodeSystems', client: :embedded_client)
+        reply = fhir_client(:embedded_client).send(:get, "$updateCodeSystems")
+        assert reply.response[:code] == 200
+
+        # Get submission data
+        resources = queries.map do |q|
+          # TODO: run query through unlogged rest client
+          fhir_search(q['endpoint'], client: :embedded_client, params: q['params'])
+          code = response[:status]
+
+          # Return all resources in the response bundle if queries are met
+          if code == 200
+            bundle = JSON.parse(response[:body])
+            bundle['entry'] ? bundle['entry'].map { |e| e['resource'] } : []
+          else
+            []
+          end
+        end.flatten.uniq { |r| r['id'] }
+
+        # Create submit data parameters
+        measure_report = create_measure_report(measure['url'], '2019-01-01', '2019-12-31')
+        params = {
+          resourceType: 'Parameters',
+          parameter: [{
+            name: 'measureReport',
+            resource: measure_report
+          }]
+        }
+
+        # Add resources to parameters
+        resources.each do |r|
+          # create unique identifier if not present on resource
+          unless r.dig('identifier')&.first&.dig('value')
+            r['identifier'] = [{}]
+            r['identifier'][0]['value'] = SecureRandom.uuid
+          end
+
+          resource_param = {
+            name: 'resource',
+            resource: r
+          }
+          params[:parameter].push(resource_param)
+        end
+        # Submit the data
+        fhir_operation("Measure/#{measure_id}/$submit-data", body: params, name: :submit_data)
+        assert_response_status(200)
+        assert_valid_json(response[:body])
+
+        resources.push(measure_report)
+
+        # GET and assert presence of all submitted resources
+        resources.each do |r|
+          identifier = r.dig('identifier')&.first&.dig('value')
+          assert !identifier.nil?, "Identifier #{identifier} was nil"
+
+          # Search for resource by identifier
+          fhir_search(r['resourceType'], params: { identifier: identifier })
+          assert_response_status(200)
+          assert_resource_type(:bundle)
+          assert_valid_json(response[:body])
+          resource_bundle = JSON.parse(response[:body])
+          assert resource_bundle['total'].positive?,
+                 "Search for a #{r['resourceType']} with identifier #{identifier} returned no results"
+        end
+      end
+    end
+
+    def create_measure_report(measure_url, period_start, period_end)
+       mr = {
+        resourceType: 'MeasureReport',
+        type: 'data-collection',
+        measure: measure_url,
+        period: {
+          start: period_start,
+          end: period_end
+        },
+        status: 'complete'
+      }
+      mr['identifier'] = [{}]
+      mr['identifier'][0]['value'] = SecureRandom.uuid
+      mr
+    end
+  end
+  # rubocop:enable Metrics/BlockLength
+end

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -70,10 +70,10 @@ module DEQMTestKit
         # Create submit data parameters
         measure_report = create_measure_report(measure['url'], '2019-01-01', '2019-12-31')
         params = {
-          resourceType: 'Parameters',
-          parameter: [{
-            name: 'measureReport',
-            resource: measure_report
+          'resourceType' => 'Parameters',
+          'parameter' => [{
+            'name' => 'measureReport',
+            'resource' => measure_report
           }]
         }
 
@@ -86,10 +86,10 @@ module DEQMTestKit
           end
 
           resource_param = {
-            name: 'resource',
-            resource: r
+            'name' => 'resource',
+            'resource' => r
           }
-          params[:parameter].push(resource_param)
+          params['parameter'].push(resource_param)
         end
         # Submit the data
         fhir_operation("Measure/#{measure_id}/$submit-data", body: params, name: :submit_data)
@@ -117,15 +117,15 @@ module DEQMTestKit
 
     def create_measure_report(measure_url, period_start, period_end)
        mr = {
-        resourceType: 'MeasureReport',
-        type: 'data-collection',
-        measure: measure_url,
-        period: {
-          start: period_start,
-          end: period_end
+        'type' => 'data-collection',
+        'measure' => measure_url,
+        'period' => {
+          'start' => period_start,
+          'end' => period_end
         },
-        status: 'complete'
+        'status' => 'complete'
       }
+      mr['resourceType'] = 'MeasureReport'
       mr['identifier'] = [{}]
       mr['identifier'][0]['value'] = SecureRandom.uuid
       mr

--- a/lib/utils/data_requirements_utils.rb
+++ b/lib/utils/data_requirements_utils.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DEQMTestKit
+  module DataRequirementsUtils
+    def get_filter_str(code_filter)
+      ret_val = '(no code filter)'
+
+      if code_filter&.code&.first
+        code = code_filter.first.code.first
+        ret_val = "(#{code.system}|#{code.code})"
+      elsif code_filter&.valueSet
+        ret_val = "(#{code_filter.valueSet})"
+      end
+
+      ret_val
+    end
+
+    def get_dr_comparison_list(data_requirement)
+      data_requirement.map do |dr|
+        dr_resource = FHIR::DataRequirement.new dr
+        cf = dr_resource.codeFilter&.first
+        filter_str = get_filter_str cf
+
+        path = cf&.path ? ".#{cf.path}" : ''
+
+        "#{dr_resource.type}#{path}#{filter_str}"
+      end
+    end
+  end
+end

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::DataRequirements do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[3] }
+  let(:group) { suite.groups[2] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   url = 'http://example.com/fhir'
@@ -25,11 +25,15 @@ RSpec.describe DEQMTestKit::DataRequirements do
     let(:test) { group.tests.first }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
-    let(:test_id) { 'test_id' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
 
     it 'passes if the expected Library was received' do
-      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: measure_id } }])
       test_library_response = FHIR::Library.new(dataRequirement: [{ type: 'Condition' }])
+      test_measure = FHIR::Measure.new(id: measure_id, name: measure_name, version: measure_version)
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
 
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
@@ -37,22 +41,26 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{test_id}/$data-requirements")
+      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
         .to_return(status: 200, body: test_library_response.to_json)
 
       # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
-      result = run(test, url: url)
+      result = run(test, url: url, measure_id: measure_id)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if a 200 is not received' do
       # external client returns 201 instead of 200
 
-      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: measure_id } }])
       test_library_response = FHIR::Library.new(dataRequirement: [{ type: 'Condition' }])
+      test_measure = FHIR::Measure.new(id: measure_id)
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
 
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
@@ -60,13 +68,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{test_id}/$data-requirements")
+      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
         .to_return(status: 201, body: test_library_response.to_json)
 
-      result = run(test, url: url)
+      result = run(test, url: url, measure_id: measure_id)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(/200/)
@@ -74,9 +82,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
     it 'fails if a Library is not received' do
       # returns a bundle not a library
-      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: test_id } }])
+      test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: measure_id } }])
 
       test_not_library_response = FHIR::Bundle.new
+      test_measure = FHIR::Measure.new(id: measure_id)
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
 
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
@@ -84,13 +96,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{test_id}/$data-requirements")
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
         .to_return(status: 200, body: test_not_library_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{test_id}/$data-requirements")
+      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
         .to_return(status: 200, body: test_not_library_response.to_json)
 
-      result = run(test, url: url)
+      result = run(test, url: url, measure_id: measure_id)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match('Bad resource type received: expected Library, but received Bundle')

--- a/spec/deqm_test_kit/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/measure_availability_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
     let(:measure_version) { '7.3.000' }
 
     it 'passes if a Measure was received' do
-      # measure_bundle['entry'][0]['resource']['id']
       resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
 
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")

--- a/spec/deqm_test_kit/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/measure_availability_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::MeasureAvailability do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[2] }
+  let(:group) { suite.groups[1] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   let(:url) { 'http://example.com/fhir' }
@@ -23,7 +23,8 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
     let(:measure_version) { '7.3.000' }
 
     it 'passes if a Measure was received' do
-      resource = FHIR::Bundle.new(total: 1)
+      # measure_bundle['entry'][0]['resource']['id']
+      resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
 
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: resource.to_json)

--- a/spec/deqm_test_kit/patient_group_spec.rb
+++ b/spec/deqm_test_kit/patient_group_spec.rb
@@ -9,99 +9,100 @@ RSpec.describe DEQMTestKit::PatientGroup do
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
   def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
-    end
-    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+    # don't run
+    # test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    # test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    # inputs.each do |name, value|
+    #   session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
+    # end
+    # Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe 'read test' do
-    let(:test) { group.tests.first }
-    let(:patient_id) { 'abc123' }
+  # describe 'read test' do
+  #   let(:test) { group.tests.first }
+  #   let(:patient_id) { 'abc123' }
 
-    it 'passes if a Patient was received' do
-      resource = FHIR::Patient.new(id: patient_id)
-      stub_request(:get, "#{url}/Patient/#{patient_id}")
-        .to_return(status: 200, body: resource.to_json)
+  #   it 'passes if a Patient was received' do
+  #     resource = FHIR::Patient.new(id: patient_id)
+  #     stub_request(:get, "#{url}/Patient/#{patient_id}")
+  #       .to_return(status: 200, body: resource.to_json)
 
-      result = run(test, url: url, patient_id: patient_id)
+  #     result = run(test, url: url, patient_id: patient_id)
 
-      expect(result.result).to eq('pass')
-    end
+  #     expect(result.result).to eq('pass')
+  #   end
 
-    it 'fails if a 200 is not received' do
-      resource = FHIR::Patient.new(id: patient_id)
-      stub_request(:get, "#{url}/Patient/#{patient_id}")
-        .to_return(status: 201, body: resource.to_json)
+  #   it 'fails if a 200 is not received' do
+  #     resource = FHIR::Patient.new(id: patient_id)
+  #     stub_request(:get, "#{url}/Patient/#{patient_id}")
+  #       .to_return(status: 201, body: resource.to_json)
 
-      result = run(test, url: url, patient_id: patient_id)
+  #     result = run(test, url: url, patient_id: patient_id)
 
-      expect(result.result).to eq('fail')
-      expect(result.result_message).to match(/200/)
-    end
+  #     expect(result.result).to eq('fail')
+  #     expect(result.result_message).to match(/200/)
+  #   end
 
-    it 'fails if a Patient is not received' do
-      resource = FHIR::Condition.new(id: patient_id)
-      stub_request(:get, "#{url}/Patient/#{patient_id}")
-        .to_return(status: 200, body: resource.to_json)
+  #   it 'fails if a Patient is not received' do
+  #     resource = FHIR::Condition.new(id: patient_id)
+  #     stub_request(:get, "#{url}/Patient/#{patient_id}")
+  #       .to_return(status: 200, body: resource.to_json)
 
-      result = run(test, url: url, patient_id: patient_id)
+  #     result = run(test, url: url, patient_id: patient_id)
 
-      expect(result.result).to eq('fail')
-      expect(result.result_message).to match(/Patient/)
-    end
+  #     expect(result.result).to eq('fail')
+  #     expect(result.result_message).to match(/Patient/)
+  #   end
 
-    it 'fails if the id received does not match the one requested' do
-      resource = FHIR::Patient.new(id: '456')
-      stub_request(:get, "#{url}/Patient/#{patient_id}")
-        .to_return(status: 200, body: resource.to_json)
+  #   it 'fails if the id received does not match the one requested' do
+  #     resource = FHIR::Patient.new(id: '456')
+  #     stub_request(:get, "#{url}/Patient/#{patient_id}")
+  #       .to_return(status: 200, body: resource.to_json)
 
-      result = run(test, url: url, patient_id: patient_id)
+  #     result = run(test, url: url, patient_id: patient_id)
 
-      expect(result.result).to eq('fail')
-      expect(result.result_message).to match(/resource with id/)
-    end
-  end
+  #     expect(result.result).to eq('fail')
+  #     expect(result.result_message).to match(/resource with id/)
+  #   end
+  # end
 
-  describe 'validation test' do
-    let(:test) { group.tests.last }
+  # describe 'validation test' do
+  #   let(:test) { group.tests.last }
 
-    it 'passes if the resource is valid' do
-      stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
-        .with(query: hash_including({}))
-        .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
+  #   it 'passes if the resource is valid' do
+  #     stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
+  #       .with(query: hash_including({}))
+  #       .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
 
-      resource = FHIR::Patient.new
-      repo_create(
-        :request,
-        name: :patient,
-        test_session_id: test_session.id,
-        response_body: resource.to_json
-      )
+  #     resource = FHIR::Patient.new
+  #     repo_create(
+  #       :request,
+  #       name: :patient,
+  #       test_session_id: test_session.id,
+  #       response_body: resource.to_json
+  #     )
 
-      result = run(test)
+  #     result = run(test)
 
-      expect(result.result).to eq('pass')
-    end
+  #     expect(result.result).to eq('pass')
+  #   end
 
-    it 'fails if the resource is not valid' do
-      stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
-        .with(query: hash_including({}))
-        .to_return(status: 200, body: error_outcome.to_json)
+  #   it 'fails if the resource is not valid' do
+  #     stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
+  #       .with(query: hash_including({}))
+  #       .to_return(status: 200, body: error_outcome.to_json)
 
-      resource = FHIR::Patient.new
-      repo_create(
-        :request,
-        name: :patient,
-        test_session_id: test_session.id,
-        response_body: resource.to_json
-      )
+  #     resource = FHIR::Patient.new
+  #     repo_create(
+  #       :request,
+  #       name: :patient,
+  #       test_session_id: test_session.id,
+  #       response_body: resource.to_json
+  #     )
 
-      result = run(test)
+  #     result = run(test)
 
-      expect(result.result).to eq('fail')
-    end
-  end
+  #     expect(result.result).to eq('fail')
+  #   end
+  # end
 end

--- a/spec/deqm_test_kit/submit_data_spec.rb
+++ b/spec/deqm_test_kit/submit_data_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+RSpec.describe DEQMTestKit::SubmitData do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+  let(:group) { suite.groups[3] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
+  url = 'http://example.com/fhir'
+  # ensure this url matches url in embedded_client in data_requirements.rb
+  let(:embedded_client) do
+    'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
+  end
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  describe 'submit data test' do
+    let(:test) { group.tests.first }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+
+    it 'passes if the submitted resources can be retrieved' do
+      test_bundle = FHIR::Bundle.new(total: 1)
+      test_measure = FHIR::Measure.new(id: measure_id)
+      identifier = SecureRandom.uuid
+      id_resource = FHIR::Identifier.new({ value: identifier })
+      test_patient = FHIR::Bundle.new(total: 1,
+                                      entry: [resource: FHIR::Patient.new({
+                                                                            id: 'PatientID', identifier: [id_resource]
+                                                                          })])
+      queries_json = [{ endpoint: 'Patient', params: {} }].to_json
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
+
+      # TODO: update, needs both get and post
+      stub_request(:get, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+      stub_request(:post, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+
+      stub_request(:get, "#{embedded_client}/Patient")
+        .to_return(status: 200, body: test_patient.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
+        .to_return(status: 200, body: {}.to_json)
+
+      stub_request(:get, "#{url}/Patient?identifier=#{identifier}")
+        .to_return(status: 200, body: test_patient.to_json)
+
+      stub_request(:get, %r{#{url}/MeasureReport\?identifier=.*})
+        .to_return(status: 200, body: test_bundle.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, queries_json: queries_json)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if submit data does not return 200' do
+      test_bundle = FHIR::Bundle.new(total: 1)
+      test_measure = FHIR::Measure.new(id: measure_id)
+      identifier = SecureRandom.uuid
+      id_resource = FHIR::Identifier.new({ value: identifier })
+      test_patient = FHIR::Bundle.new(total: 1,
+                                      entry: [resource: FHIR::Patient.new({
+                                                                            id: 'PatientID', identifier: [id_resource]
+                                                                          })])
+      queries_json = [{ endpoint: 'Patient', params: {} }].to_json
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
+
+      # TODO: update, needs both get and post
+      stub_request(:get, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+      stub_request(:post, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+
+      stub_request(:get, "#{embedded_client}/Patient")
+        .to_return(status: 200, body: test_patient.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
+        .to_return(status: 400, body: {}.to_json)
+
+      stub_request(:get, "#{url}/Patient?identifier=#{identifier}")
+        .to_return(status: 200, body: test_patient.to_json)
+
+      stub_request(:get, %r{#{url}/MeasureReport\?identifier=.*})
+        .to_return(status: 200, body: test_bundle.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, queries_json: queries_json)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the submitted retrieval does not return 200' do
+      test_bundle = FHIR::Bundle.new(total: 1)
+      test_measure = FHIR::Measure.new(id: measure_id)
+      identifier = SecureRandom.uuid
+      id_resource = FHIR::Identifier.new({ value: identifier })
+      test_patient = FHIR::Bundle.new(total: 1,
+                                      entry: [resource: FHIR::Patient.new({
+                                                                            id: 'PatientID', identifier: [id_resource]
+                                                                          })])
+      queries_json = [{ endpoint: 'Patient', params: {} }].to_json
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
+
+      # TODO: update, needs both get and post
+      stub_request(:get, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+      stub_request(:post, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+
+      stub_request(:get, "#{embedded_client}/Patient")
+        .to_return(status: 200, body: test_patient.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
+        .to_return(status: 200, body: {}.to_json)
+
+      stub_request(:get, "#{url}/Patient?identifier=#{identifier}")
+        .to_return(status: 400)
+
+      stub_request(:get, %r{#{url}/MeasureReport\?identifier=.*})
+        .to_return(status: 200, body: test_bundle.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, queries_json: queries_json)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the submitted resource cannot be found' do
+      test_bundle = FHIR::Bundle.new(total: 1)
+      test_measure = FHIR::Measure.new(id: measure_id)
+      identifier = SecureRandom.uuid
+      id_arr = [FHIR::Identifier.new({ value: identifier })]
+      test_patient = FHIR::Bundle.new(total: 1,
+                                      entry: [resource: FHIR::Patient.new({
+                                                                            id: 'PatientID', identifier: id_arr
+                                                                          })])
+      wrong_patient = FHIR::Bundle.new(total: 0)
+      queries_json = [{ endpoint: 'Patient', params: {} }].to_json
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
+
+      # TODO: update, needs both get and post
+      stub_request(:get, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+      stub_request(:post, "#{embedded_client}/$updateCodeSystems")
+        .to_return(status: 200)
+
+      stub_request(:get, "#{embedded_client}/Patient")
+        .to_return(status: 200, body: test_patient.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
+        .to_return(status: 200, body: {}.to_json)
+
+      stub_request(:get, "#{url}/Patient?identifier=#{identifier}")
+        .to_return(status: 200, body: wrong_patient.to_json)
+
+      stub_request(:get, %r{#{url}/MeasureReport\?identifier=.*})
+        .to_return(status: 200, body: test_bundle.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, queries_json: queries_json)
+      expect(result.result).to eq('fail')
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Changes from the connectathon and updates for cleaner usage of inferno core. Adds deqm-test-server and mongo to docker compose.
## New behavior
Adds submit data test group and passes data through from previous test groups to support submit data.
Starts deqm-test-server as a part of the docker compose.
Disables patient group and patient group tests.
## Code changes

- Updates docker-compose.
- Updates groups in deqm_test_kit file.
- Expands the capabilities of measure_availability and data_requirements to support submit data and utilizes more inferno core built ins.
- Adds submit_data test group, which leverages basic measure information and queries built from the data requirements to pull resources from the embedded cqf_ruler and submit them to the client under test using the `$submit-data` operation. Then checks that submitted resources can be found by searching the client under test.
- Updates and adds tests accordingly.

# Testing guidance
All tests can be run with the `rspec` command. To run the application, use `docker-compose up --build`, which may take a minute or more to start up (cqf-ruler will show a time taken until start). Access the application at http://localhost:4567 . Select the test suite and start testing. Starting with the capability statement or measure availability test, input the test url and test with either:

- http://deqm_test_server:3000/4_0_0 (needs to be loaded with at least measure 130 from connectathon via POST to http://localhost:3000/4_0_0, if you have problems loading the measure due to size, ask channel for workaround, there may be a new test server image to use )
- http://cqf_ruler:8080/cqf-ruler-r4/fhir (if cqf_ruler, there may be a bug in the preloaded image, so if you'd like to use this, you can change the image to `contentgroup/cqf-ruler:latest` in the `docker-compose.yml` and post the 130 measure bundle from connectathon to load it with data)

Once measure availability is run, it should pass the correct information through to run the data requirements test group. Data requirements should then pass through necessary information to submit data. Should look something like this:
<img width="1101" alt="Screen Shot 2021-09-28 at 10 08 33 PM" src="https://user-images.githubusercontent.com/2643955/135191143-e9e6433b-8ed5-417f-b8ab-5e561a1a3651.png">
<img width="1131" alt="Screen Shot 2021-09-28 at 10 08 52 PM" src="https://user-images.githubusercontent.com/2643955/135191142-10c57892-9436-4143-a66a-5299498905fd.png">

The data requirements test should succeed with cqf_ruler, but fail with deqm_test_server because there are still some differences between how these servers create data requirements. All other inferno tests should pass. Feel free to play with other patient data, but this currently only works with 130 (until we get a measure dropdown later).

