### PR TITLE
Measure availability negative test

### DIFF
--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -41,7 +41,7 @@ module DEQMTestKit
       title 'Measure cannot be found returns empty bundle'
       id 'measure-availability-02'
       description 'Selected measure is know not to exist on the server and returns an empty bundle'
-      uses_request :measure_search
+      makes_request :measure_search_failure
       output :null
 
       run do
@@ -49,7 +49,7 @@ module DEQMTestKit
         measure_version = '0'
 
         # Search system for measure by identifier and version
-        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search_failure)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -49,10 +49,7 @@ module DEQMTestKit
         measure_version = '0'
 
         # Search system for measure by identifier and version
-        fhir_search(
-          :measure, 
-          params: { name: measure_identifier, version: measure_version }, 
-          name: :measure_search_failure)
+        fhir_search(:measure, params: { name: measure_identifier, version: measure_version })
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -41,7 +41,7 @@ module DEQMTestKit
       title 'Measure cannot be found returns empty bundle'
       id 'measure-availability-02'
       description 'Selected measure is know not to exist on the server and returns an empty bundle'
-      makes_request :measure_search
+      uses_request :measure_search
       output :null
 
       run do

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -49,7 +49,10 @@ module DEQMTestKit
         measure_version = '0'
 
         # Search system for measure by identifier and version
-        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search_failure)
+        fhir_search(
+          :measure, 
+          params: { name: measure_identifier, version: measure_version }, 
+          name: :measure_search_failure)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -36,5 +36,27 @@ module DEQMTestKit
         output measure_id: resource.entry[0].resource.id
       end
     end
+
+    test do
+      title 'Measure cannot be found returns empty bundle'
+      id 'measure-availability-02'
+      description 'Selected measure is know not to exist on the server and returns an empty bundle'
+      makes_request :measure_search
+      output :null
+
+      run do
+        measure_identifier = 'NON-EXISTANT_MEASURE_ID'
+        measure_version = '0'
+
+        # Search system for measure by identifier and version
+        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert resource.total.zero?,
+               "Expected to return empty bundle when passed\"
+               identifier #{measure_identifier} and version #{measure_version}"
+      end
+    end
   end
 end


### PR DESCRIPTION
# Summary
Added a new integration test to the measure availability set which expects a measure-availability request to return an empty bundle when called with a measure id that does not have a corresponding measure in the system

## New behavior
Inferno measure-availability suite should not cover the test case where the serve does not have the requested measure available

## Code changes
Added a new test case to the measure-availability suite

# Testing guidance
- Start up the test kit using `docker-compose up --build`
- Navigate to [localhost:4567](localhost:4567)
- select 'DEQM Measure Operations Test Suite' and click 'start testing'
- click the play button next to Measure Availability and ensure that the popup in the bottom left corner shows 2 tests to be run.
- Check that both pass!
