### PR TITLE
Data requirements negative test cases

### DIFF
--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -21,17 +21,7 @@ module DEQMTestKit
 
     PARAMS = {
       resourceType: 'Parameters',
-      parameter: [{
-        periodStart: '2019-01-01',
-        periodEnd: '2019-12-31'
-      }]
-    }.freeze
-
-    MISSING_PARAMS = {
-      resourceType: 'Parameters',
-      parameter: [{
-        periodStart: '2019-01-01'
-      }]
+      parameter: [{}]
     }.freeze
 
     INVALID_ID = 'INVALID_ID'
@@ -96,6 +86,7 @@ module DEQMTestKit
                "Client data-requirements contains unexpected data requirements for measure #{measure_id}: #{diff}")
       end
     end
+
     test do
       title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
@@ -103,13 +94,14 @@ module DEQMTestKit
 
       run do
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{INVALID_ID}/$data-requirements", body: MISSING_PARAMS)
+        fhir_operation("Measure/#{INVALID_ID}/$data-requirements", body: PARAMS)
         assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
         assert(resource.issue[0].severity == 'error')
       end
     end
+
     test do
       title 'Check data requirements returns 400 for invalid measure id'
       id 'data-requirements-03'

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -91,10 +91,11 @@ module DEQMTestKit
       title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
       description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
-
+      input :measure_id
       run do
+
         # Run our data requirements operation on the test client server
-        fhir_operation('Measure/TEST_ID/$data-requirements', body: PARAMS)
+        fhir_operation('Measure/measure_id/$data-requirements', body: PARAMS)
         assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
@@ -103,9 +104,9 @@ module DEQMTestKit
     end
 
     test do
-      title 'Check data requirements returns 400 for invalid measure id'
+      title 'Check data requirements returns 404 for invalid measure id'
       id 'data-requirements-03'
-      description 'Data requirements returns 400 when passed a measure id which is not in the system'
+      description 'Data requirements returns 404 when passed a measure id which is not in the system'
 
       run do
         # Run our data requirements operation on the test client server
@@ -113,7 +114,7 @@ module DEQMTestKit
           "Measure/#{INVALID_ID}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
           body: PARAMS
         )
-        assert_response_status(400)
+        assert_response_status(404)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
         assert(resource.issue[0].severity == 'error')

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -93,9 +93,8 @@ module DEQMTestKit
       description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
       input :measure_id
       run do
-
         # Run our data requirements operation on the test client server
-        fhir_operation('Measure/measure_id/$data-requirements', body: PARAMS)
+        fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)
         assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -24,16 +24,17 @@ module DEQMTestKit
       parameter: [{
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31'
-
       }]
     }.freeze
 
-    PARAMS = {
+    MISSING_PARAMS = {
       resourceType: 'Parameters',
       parameter: [{
         periodStart: '2019-01-01'
       }]
     }.freeze
+
+    INVALID_ID = 'INVALID_ID'
 
     # rubocop:disable Metrics/BlockLength
     test do
@@ -54,7 +55,8 @@ module DEQMTestKit
         measure_version = resource.version
 
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS, name: :data_requirements)
+        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+                       body: PARAMS, name: :data_requirements)
         assert_response_status(200)
         assert_resource_type(:library)
         assert_valid_json(response[:body])
@@ -69,7 +71,11 @@ module DEQMTestKit
         embedded_client_id = resource.entry[0].resource.id
 
         # Run data requirements operation on embedded cqf-ruler instance
-        fhir_operation("Measure/#{embedded_client_id}/$data-requirements", body: PARAMS, client: :embedded_client)
+        fhir_operation(
+          "Measure/#{embedded_client_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+          body: PARAMS,
+          client: :embedded_client
+        )
         expected_dr = resource.dataRequirement
 
         expected_dr_strings = get_dr_comparison_list expected_dr
@@ -91,57 +97,34 @@ module DEQMTestKit
       end
     end
     test do
-      title 'Check data requirements against expected return'
+      title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
-      description 'Data requirements fails with missing parameters'
-      makes_request :data_requirements
-      output :queries_json
-      input :measure_id
+      description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
 
       run do
-        # Get measure resource from client
-        fhir_read(:measure, measure_id)
-        assert_response_status(200)
-        assert_resource_type(:measure)
-        assert_valid_json(response[:body])
-        measure_identifier = resource.name
-        measure_version = resource.version
-
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{measure_id}/$data-requirements", body: MISSING_PARAMS)
-        assert_response_status(200)
-        assert_resource_type(:library)
+        fhir_operation("Measure/#{INVALID_ID}/$data-requirements", body: MISSING_PARAMS)
+        assert_response_status(400)
         assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+    test do
+      title 'Check data requirements returns 400 for invalid measure id'
+      id 'data-requirements-03'
+      description 'Data requirements returns 400 when passed a measure id which is not in the system'
 
-        actual_dr = resource.dataRequirement
-
-        actual_dr_strings = get_dr_comparison_list actual_dr
-
-        # Search embedded cqf-ruler instance by identifier and version
-        fhir_search(:measure, client: :embedded_client,
-                              params: { name: measure_identifier, version: measure_version })
-        embedded_client_id = resource.entry[0].resource.id
-
-        # Run data requirements operation on embedded cqf-ruler instance
-        fhir_operation("Measure/#{embedded_client_id}/$data-requirements", body: PARAMS, client: :embedded_client)
-        expected_dr = resource.dataRequirement
-
-        expected_dr_strings = get_dr_comparison_list expected_dr
-
-        diff = expected_dr_strings - actual_dr_strings
-
-        # still output queries even if different from expected.
-        # TODO: output queries only if pass once they align with cqf-ruler
-        queries = get_data_requirements_queries(actual_dr)
-        output queries_json: queries.to_json
-
-        # Ensure both data requirements results libraries are identical
-        assert(diff.blank?,
-               "Client data-requirements is missing expected data requirements for measure #{measure_id}: #{diff}")
-
-        diff = actual_dr_strings - expected_dr_strings
-        assert(diff.blank?,
-               "Client data-requirements contains unexpected data requirements for measure #{measure_id}: #{diff}")
+      run do
+        # Run our data requirements operation on the test client server
+        fhir_operation(
+          "Measure/#{INVALID_ID}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+          body: PARAMS
+        )
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -94,7 +94,7 @@ module DEQMTestKit
 
       run do
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{INVALID_ID}/$data-requirements", body: PARAMS)
+        fhir_operation('Measure/TEST_ID/$data-requirements', body: PARAMS)
         assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe DEQMTestKit::DataRequirements do
     'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
   end
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+  let(:test_library_response) { FHIR::Library.new(dataRequirement: [{ type: 'Condition' }]) }
+  let(:incorrect_severity) { FHIR::OperationOutcome.new(issue: [{ severity: 'warning' }]) }
 
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
@@ -21,7 +23,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe 'data requirements test' do
+  describe 'data requirements matches embedded results test' do
     let(:test) { group.tests.first }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
@@ -29,7 +31,6 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
     it 'passes if the expected Library was received' do
       test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: measure_id } }])
-      test_library_response = FHIR::Library.new(dataRequirement: [{ type: 'Condition' }])
       test_measure = FHIR::Measure.new(id: measure_id, name: measure_name, version: measure_version)
 
       stub_request(:get, "#{url}/Measure/#{measure_id}")
@@ -176,6 +177,96 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match('Bad resource type received: expected Library, but received Bundle')
+    end
+  end
+
+  describe '$data-requirements with missing parameters' do
+    let(:test) { group.tests[1] }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+
+    it 'passes with correct OperationOutcome returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/TEST_ID/$data-requirements"
+      )
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails with incorrect status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/TEST_ID/$data-requirements"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails when resource returned is not of type OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Measure/TEST_ID/$data-requirements"
+      )
+        .to_return(status: 400, body: test_library_response.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails when severity of OperationOutcome returned is not of type error' do
+      stub_request(
+        :post,
+        "#{url}/Measure/TEST_ID/$data-requirements"
+      )
+        .to_return(status: 400, body: incorrect_severity.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+  end
+  describe '$data-requirements with invalid id' do
+    let(:test) { group.tests[2] }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails when 400 is not returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails when returned resource type is not of type OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 400, body: test_library_response.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails when severity returned is not equal to error' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 400, body: incorrect_severity.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
     end
   end
 end

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -74,10 +74,16 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
+      stub_request(
+        :post,
+        "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
       # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
@@ -100,10 +106,16 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
+      stub_request(
+        :post,
+        "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
       # TODO: pass in measure information once it is a measure_availability group input (and in below runs)

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -41,10 +41,16 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
+      stub_request(
+        :post,
+        "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
       # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
@@ -120,10 +126,16 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
+      stub_request(
+        :post,
+        "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 201, body: test_library_response.to_json)
 
       result = run(test, url: url, measure_id: measure_id)
@@ -148,10 +160,16 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_not_library_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
+      stub_request(
+        :post,
+        "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
         .to_return(status: 200, body: test_not_library_response.to_json)
 
       result = run(test, url: url, measure_id: measure_id)

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
+      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
         .to_return(status: 200, body: test_library_response.to_json)
 
       # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
@@ -120,10 +120,10 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
+      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
         .to_return(status: 200, body: test_library_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
         .to_return(status: 201, body: test_library_response.to_json)
 
       result = run(test, url: url, measure_id: measure_id)
@@ -148,10 +148,10 @@ RSpec.describe DEQMTestKit::DataRequirements do
       stub_request(:get, "#{embedded_client}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: test_measure_response.to_json)
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements")
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
         .to_return(status: 200, body: test_not_library_response.to_json)
 
-      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements")
+      stub_request(:post, "#{embedded_client}/Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01")
         .to_return(status: 200, body: test_not_library_response.to_json)
 
       result = run(test, url: url, measure_id: measure_id)

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
     it 'passes with correct OperationOutcome returned' do
       stub_request(
         :post,
-        "#{url}/Measure/TEST_ID/$data-requirements"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id)
@@ -210,7 +210,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
     it 'fails with incorrect status code returned' do
       stub_request(
         :post,
-        "#{url}/Measure/TEST_ID/$data-requirements"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id)
@@ -219,7 +219,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
     it 'fails when resource returned is not of type OperationOutcome' do
       stub_request(
         :post,
-        "#{url}/Measure/TEST_ID/$data-requirements"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 400, body: test_library_response.to_json)
       result = run(test, url: url, measure_id: measure_id)
@@ -228,7 +228,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
     it 'fails when severity of OperationOutcome returned is not of type error' do
       stub_request(
         :post,
-        "#{url}/Measure/TEST_ID/$data-requirements"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 400, body: incorrect_severity.to_json)
       result = run(test, url: url, measure_id: measure_id)
@@ -246,7 +246,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
         :post,
         "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
       )
-        .to_return(status: 400, body: error_outcome.to_json)
+        .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id)
       expect(result.result).to eq('pass')
     end
@@ -266,7 +266,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
         :post,
         "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
       )
-        .to_return(status: 400, body: test_library_response.to_json)
+        .to_return(status: 404, body: test_library_response.to_json)
       result = run(test, url: url, measure_id: measure_id)
       expect(result.result).to eq('fail')
     end
@@ -276,7 +276,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
         :post,
         "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
       )
-        .to_return(status: 400, body: incorrect_severity.to_json)
+        .to_return(status: 404, body: incorrect_severity.to_json)
       result = run(test, url: url, measure_id: measure_id)
       expect(result.result).to eq('fail')
     end


### PR DESCRIPTION
# Summary
Added negative test cases to data requirements suite

## New behavior
Inferno integration tests will now check that the server correctly returns a 400 when a data requirements request is submitted without the appropriate parameters or with an invalid measure id

## Code changes
Added tests to data-requirements suite. Updated previous test to correctly pass in query parameters

# Testing guidance
-run `rspec` and ensure all tests pass
- run `docker-compose pull`
- run `docker-compose up --build`
- navigate to [localhost:4567](http://localhost:4567) after startup of cqf-ruler
- select DEQM Measure Operations Test Suite and click start
- click the play button next to Measure Availability and input `http://deqm_test_server:3000/4_0_1`
- Once the test has passed, click the play button next to Data Requirements. Ensure that it runs three tests. The first one should fail (since our output varies compared to cqf-ruler), but the other two should pass.
- Now, return to [localhost:4567](http://localhost:4567), select DEQM Measure Operations Test Suite and click start
- Repeat the above but replace our test server url with `http://cqf_ruler:8080/cqf-ruler-r4/fhir`
- Now the data requirements first test should pass, but the next two should fail. This is because cqf-ruler returns the wrong error codes. 
