### PR TITLE
Submit data negative test cases

### DIFF
--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -111,6 +111,7 @@ module DEQMTestKit
         end
       end
     end
+
     test do
       title 'fails if a measureReport is not submitted'
       id 'submit-data-02'
@@ -136,6 +137,7 @@ module DEQMTestKit
         assert(resource.issue[0].severity == 'error')
       end
     end
+
     test do
       title 'fails if multple measureReports are submitted'
       id 'submit-data-03'

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -113,7 +113,7 @@ module DEQMTestKit
     end
 
     test do
-      title 'fails if a measureReport is not submitted'
+      title 'Fails if a measureReport is not submitted'
       id 'submit-data-02'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
       input :measure_id
@@ -139,7 +139,7 @@ module DEQMTestKit
     end
 
     test do
-      title 'fails if multple measureReports are submitted'
+      title 'Fails if multiple measureReports are submitted'
       id 'submit-data-03'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
       input :measure_id

--- a/spec/deqm_test_kit/submit_data_spec.rb
+++ b/spec/deqm_test_kit/submit_data_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DEQMTestKit::SubmitData do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe 'submit data successful upload test' do
+  describe '$submit-data successful upload test' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
 
@@ -61,7 +61,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       expect(result.result).to eq('pass')
     end
 
-    it 'fails if submit data does not return 200' do
+    it 'fails if $submit-data does not return 200' do
       test_bundle = FHIR::Bundle.new(total: 1)
       test_measure = FHIR::Measure.new(id: measure_id)
       identifier = SecureRandom.uuid

--- a/spec/deqm_test_kit/submit_data_spec.rb
+++ b/spec/deqm_test_kit/submit_data_spec.rb
@@ -181,6 +181,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       result = run(test, url: url, measure_id: measure_id, queries_json: [])
       expect(result.result).to eq('pass')
     end
+
     it 'fails when server does not return 400' do
       stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
         .to_return(status: 200, body: error_outcome.to_json)
@@ -188,6 +189,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       result = run(test, url: url, measure_id: measure_id, queries_json: [])
       expect(result.result).to eq('fail')
     end
+
     it 'fails when server returns 400 with incorrect body' do
       stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
         .to_return(status: 400, body: '')
@@ -195,6 +197,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       result = run(test, url: url, measure_id: measure_id, queries_json: [])
       expect(result.result).to eq('fail')
     end
+
     it 'fails when server returns correct status code with incorrect severity' do
       stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
         .to_return(status: 400, body: FHIR::OperationOutcome.new(issue: [{ severity: 'warning' }]).to_json)
@@ -218,6 +221,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       result = run(test, url: url, measure_id: measure_id, queries_json: [])
       expect(result.result).to eq('pass')
     end
+
     it 'fails when server does not return 400' do
       test_measure = FHIR::Measure.new(id: measure_id)
       stub_request(:get, "#{url}/Measure/#{measure_id}")
@@ -229,6 +233,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       result = run(test, url: url, measure_id: measure_id, queries_json: [])
       expect(result.result).to eq('fail')
     end
+
     it 'fails when server returns 400 with incorrect body' do
       test_measure = FHIR::Measure.new(id: measure_id)
       stub_request(:get, "#{url}/Measure/#{measure_id}")
@@ -240,6 +245,7 @@ RSpec.describe DEQMTestKit::SubmitData do
       result = run(test, url: url, measure_id: measure_id, queries_json: [])
       expect(result.result).to eq('fail')
     end
+
     it 'fails when server returns correct status code with incorrect severity' do
       test_measure = FHIR::Measure.new(id: measure_id)
       stub_request(:get, "#{url}/Measure/#{measure_id}")


### PR DESCRIPTION
# Summary
Added test cases which expect the server to return errors for known bad $submit-data requests

## New behavior
When running integration tests, the $submit-data suite will now execute 3 tests instead of 1.

## Code changes

- Added test to check for 400 returned for Parameters object submitted with no MeasureReport
- Added test to check 400 returned for Parameters object submitted with multiple MeasureReports
- Added rspec tests to check correct behavior of above tests

# Testing guidance
run `rspec` to ensure all unit tests pass
Follow the steps outline [here](https://github.com/projecttacoma/deqm-test-kit/pull/11).
Then, click the play button next to submit data and click submit
Ensure the suite runs 3 tests
- Submit Data valid submission
- fails if a measureReport is not submitted
- fails if multiple measureReports are submitted

All tests should pass!
