### PR TITLE
bumped cqf-ruler version added x-provenance support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - validator_service
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.5.0.no-vs
+    image: tacoma/cqf-ruler-preloaded:0.6.0.no-vs
     ports:
       - "8080:8080"
   validator_service:
@@ -31,8 +31,8 @@ services:
       - ./config/nginx.conf:/etc/nginx/nginx.conf
     ports:
       - "80:80"
-    command: [nginx, '-g', 'daemon off;']
-    depends_on: 
+    command: [nginx, "-g", "daemon off;"]
+    depends_on:
       - fhir_validator_app
   redis:
     image: redis

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -91,7 +91,7 @@ module DEQMTestKit
           }
           params.parameter.push(resource_param)
         end
-        #Submit the data
+        # Submit the data
         fhir_operation("Measure/#{measure_id}/$submit-data", body: params, name: :submit_data)
         assert_response_status(200)
         assert_valid_json(response[:body])

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -8,9 +8,11 @@ module DEQMTestKit
     id 'submit_data'
     title 'Submit Data'
     description 'Ensure fhir server can receive data via the $submit-data operation'
+    custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}' }
 
     fhir_client do
       url :url
+      headers custom_headers
     end
 
     fhir_client :embedded_client do
@@ -89,7 +91,7 @@ module DEQMTestKit
           }
           params.parameter.push(resource_param)
         end
-        # Submit the data
+        #Submit the data
         fhir_operation("Measure/#{measure_id}/$submit-data", body: params, name: :submit_data)
         assert_response_status(200)
         assert_valid_json(response[:body])


### PR DESCRIPTION
# Summary
Updated cqf-ruler-preloaded to use cqf-ruler-preloaded latest. Updated test kit to use new cqf-ruler preloaded and fixed bug with new x-provenance headers

## New behavior
Hopefully none! All tests and checks should pass as before

## Code changes
Pulled down cqf-ruler:latest and preloaded EXM104, EXM105, EXM124, EXM125, EXM130, and EXM511 all with no valuesets, then pushed a new image

Updated the test kit docker-compose to use the new cqf-ruler preloaded

Updated sumbit-data suite to use new x-provenance headers

# Testing guidance
Run rspec and put the deqm-test-server through the integration tests. It should be noted that the test server will fail the first data-requirements test as the output from it and cqf-ruler vary. This is expected, but all other tests should pass

Also, inspect the new cqf-ruler-preloaded instance. This can be done by:

- running `docker pull tacoma/cqf-ruler-preloaded:0.6.0.no-vs`
- then `docker run -p 8080:8080 -d tacoma/cqf-ruler-preloaded:0.4.0.no-vs`
- now, navigate to `localhost:8080/cqf-ruler-r4`
- inspect the MeasureReports, Libraries, and Measures, and ensure that none have valuesets attatched. This can be done by using the search function with no filters after clicking on each resource type in the left-side bar
- Also ensure all the Measures, MeasureReports and Libraries for the bundles listed in code changes are present
