### PR TITLE
Evaluate Measure Negative Tests

### DIFF
--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -46,12 +46,12 @@ module DEQMTestKit
     # Tests and TestGroups can be written in separate files and then included
     # using their id
     # group from: :patient_group
-    group from: :patient_everything
     group from: :measure_availability
     group from: :data_requirements
     group from: :submit_data
     group from: :evaluate_measure
     group from: :care_gaps
     group from: :bulk_import
+    group from: :patient_everything
   end
 end

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -6,6 +6,9 @@ require_relative 'deqm_test_kit/measure_availability'
 require_relative 'deqm_test_kit/data_requirements'
 require_relative 'deqm_test_kit/submit_data'
 require_relative 'deqm_test_kit/bulk_import'
+require_relative 'deqm_test_kit/evaluate_measure'
+require_relative 'deqm_test_kit/care_gaps'
+
 module DEQMTestKit
   class Suite < Inferno::TestSuite
     id :deqm_test_suite
@@ -47,6 +50,8 @@ module DEQMTestKit
     group from: :measure_availability
     group from: :data_requirements
     group from: :submit_data
+    group from: :evaluate_measure
+    group from: :care_gaps
     group from: :bulk_import
   end
 end

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -46,6 +46,7 @@ module DEQMTestKit
     # Tests and TestGroups can be written in separate files and then included
     # using their id
     # group from: :patient_group
+    group from: :patient_everything
     group from: :measure_availability
     group from: :data_requirements
     group from: :submit_data

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -46,7 +46,6 @@ module DEQMTestKit
     # Tests and TestGroups can be written in separate files and then included
     # using their id
     # group from: :patient_group
-    group from: :patient_everything
     group from: :measure_availability
     group from: :data_requirements
     group from: :submit_data

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module DEQMTestKit
+  # tests for $care-gaps
   class CareGaps < Inferno::TestGroup
     id 'care_gaps'
     title 'Gaps in Care'
@@ -21,7 +22,8 @@ module DEQMTestKit
       input :period_end, default: '2019-12-31'
 
       run do
-        fhir_operation("/Measure/$care-gaps?measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&status=open")
+        params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+        fhir_operation("/Measure/$care-gaps?#{params}&status=open")
 
         assert_response_status(200)
         assert_resource_type(:bundle)

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DEQMTestKit
+  class CareGaps < Inferno::TestGroup
+    id 'care_gaps'
+    title 'Gaps in Care'
+    description 'Ensure FHIR server can calculate gaps in care for a measure'
+
+    fhir_client do
+      url :url
+    end
+
+    INVALID_ID = 'INVALID_ID'
+
+    test do
+      title 'Check $care-gaps proper calculation'
+      id 'care-gaps-01'
+      description 'Server should properly return a gaps report'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        fhir_operation("/Measure/$care-gaps?measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&status=open")
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+      end
+    end
+  end
+end

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -38,12 +38,12 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for subject-list report'
       id 'evaluate-measure-02'
       description 'Server should properly return a subject-list measure report'
-      input :measure_id, :patient_id
+      input :measure_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list"
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=subject-list"
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
         assert_response_status(200)
@@ -70,11 +70,28 @@ module DEQMTestKit
       end
     end
 
+    # NOTE: this test will fail for deqm-test-server 
+    test do
+      title 'Check $evaluate-measure supports non-required params'
+      id 'evaluate-measure-04'
+      description 'Request returns 200 when a non-required param is included in request'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
 
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(200)
+        assert_resource_type(:measure_report)
+        assert_valid_json(response[:body])
+      end
+    end
 
     test do
       title 'Check $evaluate-measure fails for invalid measure ID'
-      id 'evaluate-measure-04'
+      id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given measure ID cannot be found'
       input :patient_id
       input :period_start, default: '2019-01-01'
@@ -93,7 +110,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for invalid patient ID'
-      id 'evaluate-measure-05'
+      id 'evaluate-measure-06'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id
       input :period_start, default: '2019-01-01'
@@ -112,7 +129,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for missing required param'
-      id 'evaluate-measure-06'
+      id 'evaluate-measure-07'
       description 'Request returns a 400 error for missing required param (periodStart)'
       input :measure_id, :patient_id
       input :period_end, default: '2019-12-31'
@@ -130,7 +147,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
-      id 'evaluate-measure-07'
+      id 'evaluate-measure-08'
       description 'Request returns 400 for missing subject param when individual report type is specified'
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
@@ -144,24 +161,6 @@ module DEQMTestKit
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
         assert(resource.issue[0].severity == 'error')
-      end
-    end
-
-    test do
-      title 'Check $evaluate-measure supports non-required params'
-      id 'evaluate-measure-08'
-      description 'Request returns 200 when a non-required param is included in request'
-      input :measure_id, :patient_id
-      input :period_start, default: '2019-01-01'
-      input :period_end, default: '2019-12-31'
-
-      run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:measure_report)
-        assert_valid_json(response[:body])
       end
     end
 

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module DEQMTestKit
+  # tests for $evaluate-measure
   class EvaluateMeasure < Inferno::TestGroup
     id 'evaluate_measure'
     title 'Evaluate Measure'
@@ -21,7 +22,8 @@ module DEQMTestKit
       input :period_end, default: '2019-12-31'
 
       run do
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}")
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
         assert_response_status(200)
         assert_resource_type(:measure_report)

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -33,7 +33,7 @@ module DEQMTestKit
       end
     end
 
-    # NOTE: this test will fail for deqm-test-server 
+    # NOTE: this test will fail for deqm-test-server
     test do
       title 'Check $evaluate-measure proper calculation for subject-list report'
       id 'evaluate-measure-02'
@@ -70,7 +70,7 @@ module DEQMTestKit
       end
     end
 
-    # NOTE: this test will fail for deqm-test-server 
+    # NOTE: this test will fail for deqm-test-server
     test do
       title 'Check $evaluate-measure supports non-required params'
       id 'evaluate-measure-04'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -30,6 +30,7 @@ module DEQMTestKit
         assert_response_status(200)
         assert_resource_type(:measure_report)
         assert_valid_json(response[:body])
+        assert(resource.type == 'individual')
       end
     end
 
@@ -49,6 +50,7 @@ module DEQMTestKit
         assert_response_status(200)
         assert_resource_type(:measure_report)
         assert_valid_json(response[:body])
+        assert(resource.type == 'subject-list')
       end
     end
 
@@ -67,6 +69,7 @@ module DEQMTestKit
         assert_response_status(200)
         assert_resource_type(:measure_report)
         assert_valid_json(response[:body])
+        assert(resource.type == 'summary')
       end
     end
 

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -11,7 +11,8 @@ module DEQMTestKit
       url :url
     end
 
-    INVALID_ID = 'INVALID_ID'
+    INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
+    INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
 
     test do
       title 'Check $evaluate-measure proper calculation'
@@ -41,7 +42,7 @@ module DEQMTestKit
 
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
-        fhir_operation("/Measure/#{INVALID_ID}/$evaluate-measure?#{params}")
+        fhir_operation("/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}")
 
         assert_response_status(404)
         assert_valid_json(response[:body])
@@ -59,7 +60,7 @@ module DEQMTestKit
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_ID}"
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}"
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
         assert_response_status(404)

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DEQMTestKit
+  class EvaluateMeasure < Inferno::TestGroup
+    id 'evaluate_measure'
+    title 'Evaluate Measure'
+    description 'Ensure FHIR server can calculate a measure'
+
+    fhir_client do
+      url :url
+    end
+
+    INVALID_ID = 'INVALID_ID'
+
+    test do
+      title 'Check $evaluate-measure proper calculation'
+      id 'evaluate-measure-01'
+      description 'Server should properly return a measure report'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}")
+
+        assert_response_status(200)
+        assert_resource_type(:measure_report)
+        assert_valid_json(response[:body])
+      end
+    end
+  end
+end

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -73,28 +73,9 @@ module DEQMTestKit
       end
     end
 
-    # NOTE: this test will fail for deqm-test-server
-    test do
-      title 'Check $evaluate-measure supports non-required params'
-      id 'evaluate-measure-04'
-      description 'Request returns 200 when a non-required param is included in request'
-      input :measure_id, :patient_id
-      input :period_start, default: '2019-01-01'
-      input :period_end, default: '2019-12-31'
-
-      run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:measure_report)
-        assert_valid_json(response[:body])
-      end
-    end
-
     test do
       title 'Check $evaluate-measure fails for invalid measure ID'
-      id 'evaluate-measure-05'
+      id 'evaluate-measure-04'
       description 'Request returns a 404 error when the given measure ID cannot be found'
       input :patient_id
       input :period_start, default: '2019-01-01'
@@ -113,7 +94,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for invalid patient ID'
-      id 'evaluate-measure-06'
+      id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id
       input :period_start, default: '2019-01-01'
@@ -132,7 +113,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for missing required param'
-      id 'evaluate-measure-07'
+      id 'evaluate-measure-06'
       description 'Request returns a 400 error for missing required param (periodStart)'
       input :measure_id, :patient_id
       input :period_end, default: '2019-12-31'
@@ -150,7 +131,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
-      id 'evaluate-measure-08'
+      id 'evaluate-measure-07'
       description 'Request returns 400 for missing subject param when individual report type is specified'
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
@@ -169,7 +150,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for invalid reportType'
-      id 'evaluate-measure-09'
+      id 'evaluate-measure-08'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -2,6 +2,7 @@
 
 module DEQMTestKit
   # tests for $evaluate-measure
+  # rubocop:disable Metrics/ClassLength
   class EvaluateMeasure < Inferno::TestGroup
     id 'evaluate_measure'
     title 'Evaluate Measure'
@@ -13,7 +14,6 @@ module DEQMTestKit
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
-
     test do
       title 'Check $evaluate-measure proper calculation'
       id 'evaluate-measure-01'
@@ -129,7 +129,7 @@ module DEQMTestKit
     test do
       title 'Check $evaluate-measure fails for inclusion of unsupported param'
       id 'evaluate-measure-07'
-      description 'Request returns 400 when an unsupported parameter (measure, practitioner, lastReceivedOn) is specified'
+      description 'Request returns 400 when an unsupported parameter is specified'
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -148,7 +148,7 @@ module DEQMTestKit
     test do
       title 'Check $evaluate-measure fails for invalid reportType'
       id 'evaluate-measure-08'
-      description 'Request returns 400 when an invalid report type is specified (not individual, population, or subject-list)'
+      description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -164,4 +164,5 @@ module DEQMTestKit
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -30,5 +30,137 @@ module DEQMTestKit
         assert_valid_json(response[:body])
       end
     end
+
+    test do
+      title 'Check $evaluate-measure fails for invalid measure ID'
+      id 'evaluate-measure-02'
+      description 'Request returns a 404 error when the given measure ID cannot be found'
+      input :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+        fhir_operation("/Measure/#{INVALID_ID}/$evaluate-measure?#{params}")
+
+        assert_response_status(404)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Check $evaluate-measure fails for invalid patient ID'
+      id 'evaluate-measure-03'
+      description 'Request returns a 404 error when the given patient ID cannot be found'
+      input :measure_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_ID}"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(404)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Check $evaluate-measure fails for missing required param'
+      id 'evaluate-measure-04'
+      description 'Request returns a 400 error for missing required param (periodStart)'
+      input :measure_id, :patient_id
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodEnd=#{period_end}&subject=#{patient_id}"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Check $evaluate-measure fails for missing subject param (individual report type)'
+      id 'evaluate-measure-05'
+      description 'Request returns 400 for missing subject param when individual report type is specified'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Check $evaluate-measure fails for (unsupported) subject-list report type'
+      id 'evaluate-measure-06'
+      description 'Request returns 501 for non-implemented report type'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(501)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Check $evaluate-measure fails for inclusion of unsupported param'
+      id 'evaluate-measure-07'
+      description 'Request returns 400 when an unsupported parameter (measure, practitioner, lastReceivedOn) is specified'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Check $evaluate-measure fails for invalid reportType'
+      id 'evaluate-measure-08'
+      description 'Request returns 400 when an invalid report type is specified (not individual, population, or subject-list)'
+      input :measure_id, :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
   end
 end

--- a/spec/deqm_test_kit/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/bulk_import_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::BulkImport do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[5] }
+  let(:group) { suite.groups[6] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   url = 'http://example.com/fhir'

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::DataRequirements do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[3] }
+  let(:group) { suite.groups[2] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   url = 'http://example.com/fhir'

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -1,0 +1,140 @@
+frozen_string_literal: true
+
+RSpec.describe DEQMTestKit::EvaluateMeasure do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+  let(:group) { suite.groups[5] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
+  url = 'http://example.com/fhir'
+  # ensure this url matches url in embedded_client in data_requirements.rb
+  let(:embedded_client) do
+    'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
+  end
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  describe '$evaluate-measure matches embedded results test' do
+    let(:test) { group.tests.first }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+
+    it 'ADD TEST' do
+    
+    end
+
+    it 'ADD TEST' do
+      
+    end
+
+    it 'ADD TEST' do
+      
+    end
+
+    it 'ADD TEST' do
+      
+    end
+
+    it 'ADD TEST' do
+      
+    end
+  end
+
+  describe '$evaluate-measure with missing parameters' do
+    let(:test) { group.tests[1] }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    # EDIT THIS DATA REQUIREMENTS CODE TO MATCH EVALUATE-MEASURE
+    it 'passes with correct OperationOutcome returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements"
+      )
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails with incorrect status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails when resource returned is not of type OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements"
+      )
+        .to_return(status: 400, body: test_library_response.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails when severity of OperationOutcome returned is not of type error' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements"
+      )
+        .to_return(status: 400, body: incorrect_severity.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+  end
+  describe '$data-requirements with invalid id' do
+    let(:test) { group.tests[2] }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 404, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails when 400 is not returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails when returned resource type is not of type OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 404, body: test_library_response.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails when severity returned is not equal to error' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
+      )
+        .to_return(status: 404, body: incorrect_severity.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      expect(result.result).to eq('fail')
+    end
+  end
+end

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -26,16 +26,25 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" }
 
     it 'passes if request has valid parameters, patient id, and measure id' do
-      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: {resourceType: 'MeasureReport', measure: measure_id}}])
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
+                                                                          measure: measure_id } }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 200, body: test_measure_report.to_json)
     end
 
     it 'fails if $evaluate-measure does not return 200' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 404, body: error_outcome.to_json) 
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/200/)
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 404, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
     end
   end
 
@@ -45,21 +54,27 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" }
-
-    INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
+    let(:INVALID_MEASURE_ID) { 'INVALID_MEASURE_ID' }
 
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url: url, patient_id: patient_id, period_start: period_start, period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 404 for invalid measure id' do
-      stub_request(:post, "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      stub_request(
+        :post,
+        "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url: url, patient_id: patient_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/404/)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/404/)
     end
   end
 
@@ -68,22 +83,28 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:INVALID_PATIENT_ID) { 'INVALID_PATIENT_ID' }
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}" }
 
-    INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
-
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 404 for invalid patient id' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/404/)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/404/)
     end
   end
 
@@ -95,17 +116,24 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:params) { "periodEnd=#{period_end}&subject=#{patient_id}" }
 
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 400 for missing param' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/400/)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/400/)
     end
   end
 
@@ -117,17 +145,24 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}" }
 
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 400 for missing subject param' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/400/)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/400/)
     end
   end
 
@@ -140,17 +175,26 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list" }
 
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 501, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 501 for unsupported subject-list' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/501/)
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/501/)
     end
   end
 
@@ -160,20 +204,31 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
-    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31" }
+    let(:params) do
+      "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
+    end
 
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 400, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 400 for unsupported param' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/400/)
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/400/)
     end
   end
 
@@ -186,17 +241,26 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID" }
 
     it 'passes with correct Operation-Outcome returned' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
         .to_return(status: 400, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if server does not return 400 for invalid reportType' do
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
-         expect(result.result).to eq('fail')
-         expect(result.result_message).to match(/400/)
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/400/)
     end
   end
 end

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -5,7 +5,7 @@ INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
 
 RSpec.describe DEQMTestKit::EvaluateMeasure do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[5] }
+  let(:group) { suite.groups[4] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   url = 'http://example.com/fhir'
@@ -20,7 +20,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe '$evaluate-measure successful test' do
+  describe '$evaluate-measure successful individual report test' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
@@ -28,7 +28,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:period_end) { '2019-12-31' }
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" }
 
-    it 'passes if request has valid parameters, patient id, and measure id' do
+    it 'passes for valid individual report' do
       test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
                                                                           measure: measure_id } }])
       stub_request(
@@ -51,8 +51,101 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure fails for invalid measure id' do
+  describe '$evaluate-measure successful subject-list report test' do
     let(:test) { group.tests[1] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=subject-list" }
+
+    it 'passes for valid subject-list report' do
+      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
+                                                                          measure: measure_id } }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: test_measure_report.to_json)
+    end
+
+    it 'fails if $evaluate-measure does not return 200' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 501, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
+    end
+  end
+
+  describe '$evaluate-measure successful population report test' do
+    let(:test) { group.tests[2] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=population" }
+
+    it 'passes for valid population report' do
+      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
+                                                                          measure: measure_id } }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: test_measure_report.to_json)
+    end
+
+    it 'fails if $evaluate-measure does not return 200' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 404, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
+    end
+  end
+
+  describe '$evaluate-measure successful inclusion of unsupported params' do
+    let(:test) { group.tests[3] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:params) do
+      "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
+    end
+
+    it 'passes for inclusion of lastReceivedOn' do
+      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
+                                                                          measure: measure_id } }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 200, body: test_measure_report.to_json)
+    end
+
+    it 'fails if server does not return 200 for unsupported param' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+      )
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
+    end
+  end
+
+  describe '$evaluate-measure fails for invalid measure id' do
+    let(:test) { group.tests[4] }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -81,7 +174,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for invalid patient id' do
-    let(:test) { group.tests[2] }
+    let(:test) { group.tests[5] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -110,7 +203,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for missing required params' do
-    let(:test) { group.tests[3] }
+    let(:test) { group.tests[6] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_end) { '2019-12-31' }
@@ -139,7 +232,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for missing subject param for individual report type' do
-    let(:test) { group.tests[4] }
+    let(:test) { group.tests[7] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -167,74 +260,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure fails for unsupported subject-list support type' do
-    let(:test) { group.tests[5] }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'numer-EXM130' }
-    let(:period_start) { '2019-01-01' }
-    let(:period_end) { '2019-12-31' }
-    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list" }
-
-    it 'passes with correct Operation-Outcome returned' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
-      )
-        .to_return(status: 501, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('pass')
-    end
-
-    it 'fails if server does not return 501 for unsupported subject-list' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
-      )
-        .to_return(status: 200, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('fail')
-      expect(result.result_message).to match(/501/)
-    end
-  end
-
-  describe '$evaluate-measure fails for unsupported param included' do
-    let(:test) { group.tests[6] }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'numer-EXM130' }
-    let(:period_start) { '2019-01-01' }
-    let(:period_end) { '2019-12-31' }
-    let(:params) do
-      "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
-    end
-
-    it 'passes with correct Operation-Outcome returned' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
-      )
-        .to_return(status: 400, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('pass')
-    end
-
-    it 'fails if server does not return 400 for unsupported param' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
-      )
-        .to_return(status: 200, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('fail')
-      expect(result.result_message).to match(/400/)
-    end
-  end
 
   describe '$evaluate-measure fails for invalid reportType' do
-    let(:test) { group.tests[7] }
+    let(:test) { group.tests[8] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -111,41 +111,8 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure successful inclusion of unsupported params' do
-    let(:test) { group.tests[3] }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'numer-EXM130' }
-    let(:period_start) { '2019-01-01' }
-    let(:period_end) { '2019-12-31' }
-    let(:params) do
-      "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
-    end
-
-    it 'passes for inclusion of lastReceivedOn' do
-      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
-                                                                          measure: measure_id } }])
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
-      )
-        .to_return(status: 200, body: test_measure_report.to_json)
-    end
-
-    it 'fails if server does not return 200 for unsupported param' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
-      )
-        .to_return(status: 400, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('fail')
-      expect(result.result_message).to match(/200/)
-    end
-  end
-
   describe '$evaluate-measure fails for invalid measure id' do
-    let(:test) { group.tests[4] }
+    let(:test) { group.tests[3] }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -174,7 +141,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for invalid patient id' do
-    let(:test) { group.tests[5] }
+    let(:test) { group.tests[4] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -203,7 +170,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for missing required params' do
-    let(:test) { group.tests[6] }
+    let(:test) { group.tests[5] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_end) { '2019-12-31' }
@@ -232,7 +199,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for missing subject param for individual report type' do
-    let(:test) { group.tests[7] }
+    let(:test) { group.tests[6] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -261,7 +228,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for invalid reportType' do
-    let(:test) { group.tests[8] }
+    let(:test) { group.tests[7] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -18,26 +18,193 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure successful test' do
-    let(:test) { groups.test.first }
+    let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) {'numer-EXM130'}
-    let(:period_start) {'2019-01-01'}
-    let(:period_end) {'2019-12-31'}
-
-    params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
 
     it 'passes if request has valid parameters, patient id, and measure id' do
       params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
-      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: {resourceType: MeasureReport, measure: measure_id}}])
+      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: {resourceType: 'MeasureReport', measure: measure_id}}])
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 200, body: test_measure_report.to_json)
     end
 
-    it 'fails if $evaluate-measure does not return 200'
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 404, body: error_outcome.to_json)
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"  
-      result = run(test, url: url, measure_id: measure_id)
-        expect(result.result).to eq('fail')
-        expect(result.result_message).to match(/200/)
+    it 'fails if $evaluate-measure does not return 200' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 404, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/200/)
+    end
+  end
+
+  describe '$evaluate-measure fails for invalid measure id' do
+    let(:test) { group.tests[1] }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+      stub_request(:post, "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}")
+        .to_return(status: 404, body: error_outcome.to_json)
+      result = run(test, url: url, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 404 for invalid measure id' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" 
+      stub_request(:post, "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, patient_id: patient_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/404/)
+    end
+  end
+
+  describe '$evaluate-measure fails for invalid patient id' do
+    let(:test) { group.tests[2] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}"
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 404, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 404 for invalid patient id' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/404/)
+    end
+  end
+
+  describe '$evaluate-measure fails for missing required params' do
+    let(:test) { group.tests[3] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodEnd=#{period_end}&subject=#{patient_id}"
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 400 for missing param' do
+      params = "periodEnd=#{period_end}&subject=#{patient_id}" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/400/)
+    end
+  end
+
+  describe '$evaluate-measure fails for missing subject param for individual report type' do
+    let(:test) { group.tests[4] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}"
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 400 for missing subject param' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/400/)
+    end
+  end
+
+  describe '$evaluate-measure fails for unsupported subject-list support type' do
+    let(:test) { group.tests[5] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list"
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 501, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 501 for unsupported subject-list' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/501/)
+    end
+  end
+
+  describe '$evaluate-measure fails for unsupported param included' do
+    let(:test) { group.tests[6] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 400 for unsupported param' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/400/)
+    end
+  end
+
+  describe '$evaluate-measure fails for invalid reportType' do
+    let(:test) { group.tests[7] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct Operation-Outcome returned' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID"
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if server does not return 400 for invalid reportType' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID" 
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
+         expect(result.result).to eq('fail')
+         expect(result.result_message).to match(/400/)
+    end
   end
 end

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -260,7 +260,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-
   describe '$evaluate-measure fails for invalid reportType' do
     let(:test) { group.tests[8] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -23,16 +23,15 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" }
 
     it 'passes if request has valid parameters, patient id, and measure id' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
       test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: {resourceType: 'MeasureReport', measure: measure_id}}])
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 200, body: test_measure_report.to_json)
     end
 
     it 'fails if $evaluate-measure does not return 200' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 404, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -45,11 +44,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" }
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
       stub_request(:post, "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}")
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url: url, patient_id: patient_id, period_start: period_start, period_end: period_end)
@@ -57,7 +56,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 404 for invalid measure id' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" 
       stub_request(:post, "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, patient_id: patient_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -70,11 +68,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}" }
 
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}"
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
@@ -82,7 +80,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 404 for invalid patient id' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -95,9 +92,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodEnd=#{period_end}&subject=#{patient_id}" }
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodEnd=#{period_end}&subject=#{patient_id}"
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_end: period_end)
@@ -105,7 +102,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 400 for missing param' do
-      params = "periodEnd=#{period_end}&subject=#{patient_id}" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -118,9 +114,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}" }
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}"
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
@@ -128,7 +124,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 400 for missing subject param' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -142,9 +137,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list" }
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list"
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 501, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
@@ -152,7 +147,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 501 for unsupported subject-list' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=subject-list" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -166,9 +160,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31" }
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31"
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
@@ -176,7 +170,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 400 for unsupported param' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&lastReceivedOn=2019-12-31" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')
@@ -190,9 +183,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
+    let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID" }
 
     it 'passes with correct Operation-Outcome returned' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID"
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
@@ -200,7 +193,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if server does not return 400 for invalid reportType' do
-      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID" 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 200, body: error_outcome.to_json) 
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start, period_end: period_end)
          expect(result.result).to eq('fail')

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
+INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
+
 RSpec.describe DEQMTestKit::EvaluateMeasure do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
   let(:group) { suite.groups[5] }
@@ -54,7 +57,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}" }
-    let(:INVALID_MEASURE_ID) { 'INVALID_MEASURE_ID' }
 
     it 'passes with correct Operation-Outcome returned' do
       stub_request(
@@ -83,7 +85,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
-    let(:INVALID_PATIENT_ID) { 'INVALID_PATIENT_ID' }
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{INVALID_PATIENT_ID}" }
 
     it 'passes with correct Operation-Outcome returned' do

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -1,4 +1,4 @@
-frozen_string_literal: true
+# frozen_string_literal: true
 
 RSpec.describe DEQMTestKit::EvaluateMeasure do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
@@ -6,10 +6,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   url = 'http://example.com/fhir'
-  # ensure this url matches url in embedded_client in data_requirements.rb
-  let(:embedded_client) do
-    'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
-  end
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
   def run(runnable, inputs = {})
@@ -21,120 +17,27 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe '$evaluate-measure matches embedded results test' do
-    let(:test) { group.tests.first }
-    let(:measure_name) { 'EXM130' }
-    let(:measure_version) { '7.3.000' }
+  describe '$evaluate-measure successful test' do
+    let(:test) { groups.test.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) {'numer-EXM130'}
+    let(:period_start) {'2019-01-01'}
+    let(:period_end) {'2019-12-31'}
 
-    it 'ADD TEST' do
-    
+    params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+
+    it 'passes if request has valid parameters, patient id, and measure id' do
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+      test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: {resourceType: MeasureReport, measure: measure_id}}])
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        .to_return(status: 200, body: test_measure_report.to_json)
     end
 
-    it 'ADD TEST' do
-      
-    end
-
-    it 'ADD TEST' do
-      
-    end
-
-    it 'ADD TEST' do
-      
-    end
-
-    it 'ADD TEST' do
-      
-    end
-  end
-
-  describe '$evaluate-measure with missing parameters' do
-    let(:test) { group.tests[1] }
-    let(:measure_name) { 'EXM130' }
-    let(:measure_version) { '7.3.000' }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
-    # EDIT THIS DATA REQUIREMENTS CODE TO MATCH EVALUATE-MEASURE
-    it 'passes with correct OperationOutcome returned' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
-      )
-        .to_return(status: 400, body: error_outcome.to_json)
+    it 'fails if $evaluate-measure does not return 200'
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}").to_return(status: 404, body: error_outcome.to_json)
+      params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"  
       result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('pass')
-    end
-    it 'fails with incorrect status code returned' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
-      )
-        .to_return(status: 200, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('fail')
-    end
-    it 'fails when resource returned is not of type OperationOutcome' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
-      )
-        .to_return(status: 400, body: test_library_response.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('fail')
-    end
-    it 'fails when severity of OperationOutcome returned is not of type error' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
-      )
-        .to_return(status: 400, body: incorrect_severity.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('fail')
-    end
-  end
-  describe '$data-requirements with invalid id' do
-    let(:test) { group.tests[2] }
-    let(:measure_name) { 'EXM130' }
-    let(:measure_version) { '7.3.000' }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
-
-    it 'passes with correct Operation-Outcome returned' do
-      stub_request(
-        :post,
-        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
-      )
-        .to_return(status: 404, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('pass')
-    end
-
-    it 'fails when 400 is not returned' do
-      stub_request(
-        :post,
-        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
-      )
-        .to_return(status: 200, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('fail')
-    end
-
-    it 'fails when returned resource type is not of type OperationOutcome' do
-      stub_request(
-        :post,
-        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
-      )
-        .to_return(status: 404, body: test_library_response.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('fail')
-    end
-
-    it 'fails when severity returned is not equal to error' do
-      stub_request(
-        :post,
-        "#{url}/Measure/INVALID_ID/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01"
-      )
-        .to_return(status: 404, body: incorrect_severity.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      expect(result.result).to eq('fail')
-    end
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match(/200/)
   end
 end

--- a/spec/deqm_test_kit/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/measure_availability_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::MeasureAvailability do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[2] }
+  let(:group) { suite.groups[1] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/patient_everything_spec.rb
+++ b/spec/deqm_test_kit/patient_everything_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 
 RSpec.describe DEQMTestKit::PatientEverything do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[6] }
+  let(:group) { suite.groups[7] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/patient_everything_spec.rb
+++ b/spec/deqm_test_kit/patient_everything_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 
 RSpec.describe DEQMTestKit::PatientEverything do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[1] }
+  let(:group) { suite.groups[6] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/submit_data_spec.rb
+++ b/spec/deqm_test_kit/submit_data_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::SubmitData do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[4] }
+  let(:group) { suite.groups[3] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   url = 'http://example.com/fhir'


### PR DESCRIPTION
# Summary
This PR creates negative tests and RSpec (unit) tests for the `$evaluate-measure` operation.

## New behavior
The `$evaluate-measure` and `$care-gaps` operations now have basic tests thanks to the great Matt Gramigna.

The `$evaluate-measure` test group contains positive and negative tests. For positive tests, the test group checks that individual, population, and subject-list reports can be created (NOTE: the subject-list test will fail for deqm-test-server). There is also a positive test for the support of non-required params (NOTE: this will fail in deqm-test-server because some of the non-required params are not currently supported). The negative requests cover various situations: missing required params, missing `subject` param for an `individual` `reportType`, and the inclusion of an invalid `reportType`.

## Code changes
The `deqm_test_kit/evaluate_measure.rb` file contains the positive and negative tests for the operation. The `evaluate_measure_spec.rb` file creates RSpec tests for both positive and negative test cases.

# Testing guidance
All tests can be run using the `rspec` command. To run the application, make sure you have `docker` running, then run the commands `docker-compose pull` followed by `docker-compose up --build`. Navigate to `http://localhost:4567` and select the test suite. Click the play button for `$evaluate-measure` and check that the tests pass. For the url, use `http://deqm_test_server:3000/4_0_1`. I used `measure-EXM130-7.3.000` for the measure id and `numer-EXM130` for the patient id.
