### PR TITLE
Regular $import test group

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,11 +50,14 @@ services:
   deqm_test_server:
     depends_on:
       - mongo
+      - redis
     image: tacoma/deqm-test-server:latest
     environment:
       DB_HOST: mongo
       DB_PORT: 27017
       DB_NAME: deqm-test-server-dev
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
     ports:
       - "3000:3000"
     command: npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       DB_NAME: deqm-test-server-dev
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      NODE_TLS_REJECT_UNAUTHORIZED: 0
     ports:
       - "3000:3000"
     command: npm start

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -5,6 +5,7 @@ require_relative 'deqm_test_kit/patient_everything'
 require_relative 'deqm_test_kit/measure_availability'
 require_relative 'deqm_test_kit/data_requirements'
 require_relative 'deqm_test_kit/submit_data'
+require_relative 'deqm_test_kit/bulk_submit_data'
 require_relative 'deqm_test_kit/bulk_import'
 require_relative 'deqm_test_kit/evaluate_measure'
 require_relative 'deqm_test_kit/care_gaps'
@@ -51,6 +52,7 @@ module DEQMTestKit
     group from: :submit_data
     group from: :evaluate_measure
     group from: :care_gaps
+    group from: :bulk_submit_data
     group from: :bulk_import
     group from: :patient_everything
   end

--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -26,7 +26,7 @@ module DEQMTestKit
     test do
       title 'Ensure data can be accepted'
       id 'bulk-import-01'
-      description 'POST to $import and the response is a 202'
+      description 'POST to $import returns 202 response, bulk status endpoint returns 200 response'
       run do
         params[:parameter][0][:valueString].concat "?_type=#{types}" if types
         fhir_operation('$import', body: params, name: :bulk_import)

--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# rubocop:disable Style/FrozenStringLiteralComment
 
 require_relative '../utils/bulk_import_utils'
 module DEQMTestKit
@@ -9,6 +9,8 @@ module DEQMTestKit
     title 'Non-Measure-Specific Bulk Import'
     description 'Ensure the fhir server can accept bulk data import requests in the non-measure-specific case'
 
+    input :types, optional: true,
+                  description: 'string of comma-delimited FHIR resource types'
     params = {
       resourceType: 'Parameters',
       parameter: [
@@ -17,7 +19,7 @@ module DEQMTestKit
           valueString: 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
         }
       ]
-    }.freeze
+    }
     fhir_client do
       url :url
     end
@@ -26,6 +28,7 @@ module DEQMTestKit
       id 'bulk-import-01'
       description 'POST to $import and the response is a 202'
       run do
+        params[:parameter][0][:valueString].concat "?_type=#{types}" if types
         fhir_operation('$import', body: params, name: :bulk_import)
         location_header = response[:headers].find { |h| h.name == 'content-location' }
         # temporary fix for extra 4_0_1
@@ -48,3 +51,4 @@ module DEQMTestKit
     end
   end
 end
+# rubocop:enable Style/FrozenStringLiteralComment

--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -26,7 +26,7 @@ module DEQMTestKit
       id 'bulk-import-01'
       description 'POST to $import and the response is a 202'
       run do
-        fhir_operation("$import", body: params, name: :bulk_import)
+        fhir_operation('$import', body: params, name: :bulk_import)
         location_header = response[:headers].find { |h| h.name == 'content-location' }
         # temporary fix for extra 4_0_1
         polling_url = "#{url}/#{location_header.value.sub('4_0_1/', '')}"

--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -6,7 +6,7 @@ module DEQMTestKit
   class BulkImport < Inferno::TestGroup
     include BulkImportUtils
     id 'bulk_import'
-    title 'Bulk Import'
+    title 'Non-Measure-Specific Bulk Import'
     description 'Ensure the fhir server can accept bulk data import requests in the non-measure-specific case'
 
     params = {

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -34,7 +34,7 @@ module DEQMTestKit
     test do
       title 'Ensure data can be accepted'
       id 'bulk-submit-data-01'
-      description 'Send the data to the server and the response is a 202'
+      description 'POST to $submit-data returns 202 response, bulk status endpoint returns 200 response'
       run do
         assert(measure_id,
                'No measure selected. Run Measure Availability prior to running the bulk import test group.')

--- a/spec/deqm_test_kit/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/bulk_import_spec.rb
@@ -1,45 +1,39 @@
 # frozen_string_literal: true
 
 RSpec.describe DEQMTestKit::BulkImport do
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[6] }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
-  url = 'http://example.com/fhir'
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
-    end
-    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
-  end
-
-  describe 'The server is able to perform bulk data tasks' do
-    let(:test) { group.tests[0] }
-    let(:measure_name) { 'EXM130' }
-    let(:measure_version) { '7.3.000' }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+    let(:group) { suite.groups[7] }
+    let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+    let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
     url = 'http://example.com/fhir'
-    it 'passes on successful $bulkImport' do
-      test_measure = FHIR::Measure.new(id: measure_id, name: measure_name, version: measure_version)
-      resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
+  
+    def run(runnable, inputs = {})
+      test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+      test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+      inputs.each do |name, value|
+        session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
+      end
+      Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+    end
+  
+    describe 'The server is able to perform bulk data tasks' do
+      let(:test) { group.tests[0] }
+      url = 'http://example.com/fhir'
+      it 'passes on successful $import' do
 
-      stub_request(:get, "#{url}/Measure/#{measure_id}")
-        .to_return(status: 200, body: test_measure.to_json)
+        resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
 
-      stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
-        .to_return(status: 200, body: resource.to_json, headers: { 'content-location': 'location' })
-      polling_url = "#{url}/location"
-      stub_request(:get, polling_url)
-        .to_return(status: 202, body: resource.to_json).times(3)
-
-      stub_request(:get, polling_url)
-        .to_return(status: 200, body: resource.to_json)
-      result = run(test, url: url, measure_id: measure_id)
-      # check that we get a 202 off a bulk data request
-      expect(result.result).to eq('pass')
+        stub_request(:post, "#{url}/$import")
+          .to_return(status: 200, body: resource.to_json, headers: { 'content-location': 'location' })
+        polling_url = "#{url}/location"
+        stub_request(:get, polling_url)
+          .to_return(status: 202, body: resource.to_json).times(3)
+  
+        stub_request(:get, polling_url)
+          .to_return(status: 200, body: resource.to_json)
+        result = run(test, url: url)
+        # check that we get a 202 off a bulk data request
+        expect(result.result).to eq('pass')
+      end
     end
   end
-end

--- a/spec/deqm_test_kit/bulk_submit_data_spec.rb
+++ b/spec/deqm_test_kit/bulk_submit_data_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe DEQMTestKit::BulkSubmitData do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+  let(:group) { suite.groups[6] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
+  url = 'http://example.com/fhir'
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name: name, value: value)
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  describe 'The server is able to perform bulk data tasks' do
+    let(:test) { group.tests[0] }
+    let(:measure_name) { 'EXM130' }
+    let(:measure_version) { '7.3.000' }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    url = 'http://example.com/fhir'
+    it 'passes on successful $bulkImport' do
+      test_measure = FHIR::Measure.new(id: measure_id, name: measure_name, version: measure_version)
+      resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
+
+      stub_request(:get, "#{url}/Measure/#{measure_id}")
+        .to_return(status: 200, body: test_measure.to_json)
+
+      stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
+        .to_return(status: 200, body: resource.to_json, headers: { 'content-location': 'location' })
+      polling_url = "#{url}/location"
+      stub_request(:get, polling_url)
+        .to_return(status: 202, body: resource.to_json).times(3)
+
+      stub_request(:get, polling_url)
+        .to_return(status: 200, body: resource.to_json)
+      result = run(test, url: url, measure_id: measure_id)
+      # check that we get a 202 off a bulk data request
+      expect(result.result).to eq('pass')
+    end
+  end
+end

--- a/spec/deqm_test_kit/patient_everything_spec.rb
+++ b/spec/deqm_test_kit/patient_everything_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 
 RSpec.describe DEQMTestKit::PatientEverything do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[7] }
+  let(:group) { suite.groups[8] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'deqm_test_suite') }
   let(:url) { 'http://example.com/fhir' }


### PR DESCRIPTION
# Summary
Added test group for $import and renamed the existing bulk import test group to "bulk_submit_data."

## New behavior
Test group functionality was added for $import. Once the test kit is up and running, you will see the new test group, titled "Non-Measure-Specific Bulk Import." When a url is provided (http://deqm_test_server:3000/4_0_1), a POST request will be sent to `$import`.

## Code changes
The new `bulk_import.rb` file contains the test group for non-specific bulk import. This test group is very similar to the "bulk submit data" test group, except it
- does not require a measure
- calls $import in the `fhir_operation` instead of `Measure/id/$submit-data`
- does not take in a `measureReport` object in the `parameter` array

# Testing guidance
Run the `rspec` tests and ensure that they all pass. Start up the test kit with `docker-compose up --build` and check that the non-measure-specific bulk import test group appears. When running the test, note that a 500 error will be thrown - check that this is the same 500 error that comes up for the bulk submit data test group (error about Redis connection).
