### PR TITLE
Changes from connectathon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,16 @@ services:
       - redis
     image: tacoma/deqm-test-server:latest
     environment:
+      HOST: deqm_test_server
+      PORT: 3000
       DB_HOST: mongo
       DB_PORT: 27017
       DB_NAME: deqm-test-server-dev
       REDIS_HOST: redis
       REDIS_PORT: 6379
       NODE_TLS_REJECT_UNAUTHORIZED: 0
+      IMPORT_WORKERS: 2
+      NDJSON_WORKERS: 2
     ports:
       - "3000:3000"
     command: npm start

--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -16,7 +16,7 @@ module DEQMTestKit
       parameter: [
         {
           name: 'exportUrl',
-          valueString: 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
+          valueUrl: 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
         }
       ]
     }
@@ -28,11 +28,10 @@ module DEQMTestKit
       id 'bulk-import-01'
       description 'POST to $import returns 202 response, bulk status endpoint returns 200 response'
       run do
-        params[:parameter][0][:valueString].concat "?_type=#{types}" if types
+        params[:parameter][0][:valueUrl].concat "?_type=#{types}" if types
         fhir_operation('$import', body: params, name: :bulk_import)
         location_header = response[:headers].find { |h| h.name == 'content-location' }
-        # temporary fix for extra 4_0_1
-        polling_url = "#{url}/#{location_header.value.sub('4_0_1/', '')}"
+        polling_url = location_header.value
         wait_time = 1
         start = Time.now
         seconds_used = 0

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -23,7 +23,7 @@ module DEQMTestKit
         },
         {
           name: 'exportUrl',
-          valueString: 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir'
+          valueUrl: 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir'
         }
       ]
     }.freeze
@@ -42,8 +42,7 @@ module DEQMTestKit
         assert_valid_json(response[:body])
         fhir_operation("Measure/#{measure_id}/$submit-data", body: params, name: :submit_data)
         location_header = response[:headers].find { |h| h.name == 'content-location' }
-        # temporary fix for extra 4_0_1
-        polling_url = "#{url}/#{location_header.value.sub('4_0_1/', '')}"
+        polling_url = location_header.value
         wait_time = 1
         start = Time.now
         seconds_used = 0

--- a/spec/deqm_test_kit/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/bulk_import_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe DEQMTestKit::BulkImport do
     url = 'http://example.com/fhir'
     it 'passes on successful $import' do
       resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
+      polling_url = "#{url}/location"
 
       stub_request(:post, "#{url}/$import")
-        .to_return(status: 200, body: resource.to_json, headers: { 'content-location': 'location' })
-      polling_url = "#{url}/location"
+        .to_return(status: 200, body: resource.to_json, headers: { 'content-location': polling_url })
       stub_request(:get, polling_url)
         .to_return(status: 202, body: resource.to_json).times(3)
 

--- a/spec/deqm_test_kit/bulk_submit_data_spec.rb
+++ b/spec/deqm_test_kit/bulk_submit_data_spec.rb
@@ -26,12 +26,14 @@ RSpec.describe DEQMTestKit::BulkSubmitData do
       test_measure = FHIR::Measure.new(id: measure_id, name: measure_name, version: measure_version)
       resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
 
+      polling_url = "#{url}/location"
+
       stub_request(:get, "#{url}/Measure/#{measure_id}")
         .to_return(status: 200, body: test_measure.to_json)
 
       stub_request(:post, "#{url}/Measure/#{measure_id}/$submit-data")
-        .to_return(status: 200, body: resource.to_json, headers: { 'content-location': 'location' })
-      polling_url = "#{url}/location"
+        .to_return(status: 200, body: resource.to_json, headers: { 'content-location': polling_url })
+
       stub_request(:get, polling_url)
         .to_return(status: 202, body: resource.to_json).times(3)
 


### PR DESCRIPTION
# Summary

Not too many updates here, just addressing some of the TODO workarounds that we initially had and updating the request bodies to be proper.

## New behavior

* Bulk submit data should fail with 500 after a few polls because `_typeFilter` is invalid
* Regular bulk import should pass entirely

## Code changes

* Update environment of deqm-test-server to reflect new environment variables
* `valueString` -> `valueUrl` where applicable
* Update parsing of `content-location` header to use as a full URL since it is no longer a slug when returned from the server
* Update tests with proper content-location header

# Testing guidance

Test the two bulk data groups:

1. Test the bulk submit-data with measure id `measure-EXM130-7.3.000` (ensure you have posted this measure bundle to deqm-test-server beforehand). Should get 500 with error message that the export server gave us 404 (this is because it doesn't support `_typeFilter` which is default behavior in bulk submit data!
2. Test the non measure-specific bulk $import group with whatever types you want, e.g. `Patient`; `Patient,Encounter,Procedure`, completely blank. It will take a little while but should pass and get an operation ndjson URL in the response.
