### PR TITLE
Regular import bug fix

### DIFF
--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -10,34 +10,30 @@ module DEQMTestKit
     description 'Ensure the fhir server can accept bulk data import requests in the non-measure-specific case'
 
     default_url = 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
-    params = {
-      resourceType: 'Parameters',
-      parameter: [
-        {
-          name: 'exportUrl',
-          valueUrl: default_url
-        }
-      ]
-    }
+
     fhir_client do
       url :url
     end
+    # rubocop:disable Metrics/BlockLength
     test do
       title 'Ensure data can be accepted'
       id 'bulk-import-01'
       description 'POST to $import returns 202 response, bulk status endpoint returns 200 response'
 
       input :types, optional: true,
-                  description: 'string of comma-delimited FHIR resource types'
-      #input :params, default: default_params
+                    description: 'string of comma-delimited FHIR resource types'
+
+      params = {
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'exportUrl',
+            valueUrl: default_url
+          }
+        ]
+      }
       run do
-        if types.length > 0
-          puts 'AAAAAAAAAAAA'
-          puts defined?(types)
-          puts 'BBBBBBB'
-          puts  params[:parameter][0][:valueUrl]
-          params[:parameter][0][:valueUrl].concat "?_type=#{types}" 
-        end
+        params[:parameter][0][:valueUrl] = default_url + "?_type=#{types}" if types.length.positive?
         fhir_operation('$import', body: params, name: :bulk_import)
         location_header = response[:headers].find { |h| h.name == 'content-location' }
         polling_url = location_header.value
@@ -56,9 +52,9 @@ module DEQMTestKit
           sleep wait_time
         end
         assert_response_status(200)
-        #@@params[:parameter][0][:valueUrl] = default_url
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end
 # rubocop:enable Style/FrozenStringLiteralComment

--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -9,14 +9,13 @@ module DEQMTestKit
     title 'Non-Measure-Specific Bulk Import'
     description 'Ensure the fhir server can accept bulk data import requests in the non-measure-specific case'
 
-    input :types, optional: true,
-                  description: 'string of comma-delimited FHIR resource types'
+    default_url = 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
     params = {
       resourceType: 'Parameters',
       parameter: [
         {
           name: 'exportUrl',
-          valueUrl: 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
+          valueUrl: default_url
         }
       ]
     }
@@ -27,8 +26,18 @@ module DEQMTestKit
       title 'Ensure data can be accepted'
       id 'bulk-import-01'
       description 'POST to $import returns 202 response, bulk status endpoint returns 200 response'
+
+      input :types, optional: true,
+                  description: 'string of comma-delimited FHIR resource types'
+      #input :params, default: default_params
       run do
-        params[:parameter][0][:valueUrl].concat "?_type=#{types}" if types
+        if types.length > 0
+          puts 'AAAAAAAAAAAA'
+          puts defined?(types)
+          puts 'BBBBBBB'
+          puts  params[:parameter][0][:valueUrl]
+          params[:parameter][0][:valueUrl].concat "?_type=#{types}" 
+        end
         fhir_operation('$import', body: params, name: :bulk_import)
         location_header = response[:headers].find { |h| h.name == 'content-location' }
         polling_url = location_header.value
@@ -36,6 +45,7 @@ module DEQMTestKit
         start = Time.now
         seconds_used = 0
         timeout = 120
+
         loop do
           get(polling_url)
           wait_time = get_retry_or_backoff_time(wait_time, response)
@@ -46,6 +56,7 @@ module DEQMTestKit
           sleep wait_time
         end
         assert_response_status(200)
+        #@@params[:parameter][0][:valueUrl] = default_url
       end
     end
   end

--- a/spec/deqm_test_kit/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/bulk_import_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DEQMTestKit::BulkImport do
   describe 'The server is able to perform bulk data tasks' do
     let(:test) { group.tests[0] }
     url = 'http://example.com/fhir'
+
     it 'passes on successful $import' do
       resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
       polling_url = "#{url}/location"
@@ -30,7 +31,7 @@ RSpec.describe DEQMTestKit::BulkImport do
 
       stub_request(:get, polling_url)
         .to_return(status: 200, body: resource.to_json)
-      result = run(test, url: url)
+      result = run(test, url: url, types: 'Patient')
       # check that we get a 202 off a bulk data request
       expect(result.result).to eq('pass')
     end


### PR DESCRIPTION
# Summary
Changes were made to the regular bulk import test so that the `valueUrl` properly resets with each new test.

## New behavior
Previously, the functionality was fine when running the test once. However, when running the test a second time, the `valueUrl` on the parameters object would not reset. For example, if we ran the test once with type = "Patient," and then we ran the test again with type = "Procedure," the test would end up with a `valueUrl` like this: `[url]/$export/_type=Patient_type=Procedure`. This would result in a 500 error being thrown.

Now, the `params` object successfully resets at the end of the test, and so we can run the test multiple times without getting any errors.

## Code changes
I moved the `params` object so that it is within the test, rather than just being within the class. 

I made some changes to how the `valueUrl` is actually updated. Turns out, the `types` input gets set to an empty string if the user does not specify any types in the UI. Therefore, I changed the if statement to check that the length of `types` is positive before changing the `valueUrl`. I think empty string is truthy in Ruby, so the previous check `if types` was landing us in the if block, and so `"type="` was being tacked onto the `valueUrl`. 

Also, the use of `concat` was causing the `valueUrl` to not reset, so I changed it to `default_url + _type=#{types}`. I tried doing `+= _types=#{types}`, but that also caused it not to reset either. 

# Testing guidance
Run the `rspec` tests and ensure that they all pass. 

Start up the test kit with `docker-compose up --build.` Try to run the non-measure-specific import test twice. For the first run, use `http://deqm_test_server:3000/4_0_1` for the URL and `Patient` for the type. Check that this passes. Then, use `http://deqm_test_server:3000/4_0_1` for the URL again and `Procedure` for the type. Check that this passes and that the `valueUrl` in the http request ends with `$export?_type=Procedure` and not `$export?_type=Patient_type=Procedure`. You can also try running without specifying any types. This will time out, but you can check that a 500 error does not get thrown right away (it used to throw 500 because it would tack on `"type="`).