### PR TITLE
switched docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - validator_service
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.6.0.no-vs
+    image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
     ports:
       - "8080:8080"
   validator_service:
@@ -51,7 +51,7 @@ services:
     depends_on:
       - mongo
       - redis
-    image: tacoma/deqm-test-server:latest
+    image: mitrehealthdocker/deqm-test-server:latest
     environment:
       HOST: deqm_test_server
       PORT: 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,8 @@ services:
       - redis
     image: mitrehealthdocker/deqm-test-server:latest
     environment:
-      HOST: deqm_test_server
-      PORT: 3000
+      SERVER_HOST: deqm_test_server
+      SERVER_PORT: 3000
       DB_HOST: mongo
       DB_PORT: 27017
       DB_NAME: deqm-test-server-dev


### PR DESCRIPTION
# Summary
Updated the docker-compose to use images of cqf-ruler-preloaded and deqm-test-server from mitrehealthdocker organization. To be reviewed with [DEQM-test-server #88](https://github.com/projecttacoma/deqm-test-server/pull/88) and [fqm-execution-service #25](https://github.com/projecttacoma/fqm-execution-service/pull/25) 

## New behavior
The test kit's image for deqm-test-server and cqf-ruler preloaded will now follow the image stored in the mitrehealthdocker org

## Code changes

# Testing guidance
- Run `docker-compose pull`
- Run `docker-compose up --build`
- Run all inferno core tests using both the test server and cqf-ruler-preloaded as the server under test. Results should be identical to what you see in main
