### PR TITLE
Radio button input for measures

### DIFF
--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require_relative '../utils/bulk_import_utils'
+require 'json'
+$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+
 module DEQMTestKit
   # BulkImport test group ensure the fhir server can accept bulk data import requests
   class BulkSubmitData < Inferno::TestGroup
@@ -9,30 +12,7 @@ module DEQMTestKit
     title 'Bulk Submit Data'
     description 'Ensure the fhir server can accept bulk data import requests when a measure is specified'
 
-    input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }, 
-        ]
-      } 
+    input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}', prefer: 'respond-async' }
     params = {
       resourceType: 'Parameters',

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -12,7 +12,9 @@ module DEQMTestKit
     description 'Ensure the fhir server can accept bulk data import requests when a measure is specified'
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
+
+    input :measure_id, measure_id_args
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}', prefer: 'respond-async' }
     params = {
       resourceType: 'Parameters',

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -2,7 +2,6 @@
 
 require_relative '../utils/bulk_import_utils'
 require 'json'
-$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # BulkImport test group ensure the fhir server can accept bulk data import requests
@@ -12,7 +11,8 @@ module DEQMTestKit
     title 'Bulk Submit Data'
     description 'Ensure the fhir server can accept bulk data import requests when a measure is specified'
 
-    input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+    input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}', prefer: 'respond-async' }
     params = {
       resourceType: 'Parameters',

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -9,7 +9,30 @@ module DEQMTestKit
     title 'Bulk Submit Data'
     description 'Ensure the fhir server can accept bulk data import requests when a measure is specified'
 
-    input :measure_id
+    input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }, 
+        ]
+      } 
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}', prefer: 'respond-async' }
     params = {
       resourceType: 'Parameters',

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -12,7 +12,7 @@ module DEQMTestKit
     description 'Ensure the fhir server can accept bulk data import requests when a measure is specified'
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
+    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
 
     input :measure_id, measure_id_args
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}', prefer: 'respond-async' }

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
+
 require 'json'
-$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # tests for $care-gaps
@@ -14,13 +14,15 @@ module DEQMTestKit
       url :url
     end
 
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+
     INVALID_ID = 'INVALID_ID'
 
     test do
       title 'Check $care-gaps proper calculation'
       id 'care-gaps-01'
       description 'Server should properly return a gaps report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -39,7 +41,7 @@ module DEQMTestKit
       title 'Check $care-gaps missing required parameter'
       id 'care-gaps-02'
       description 'Server should return a 400 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_end, default: '2019-12-31'
 
@@ -57,7 +59,7 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid optional parameters'
       id 'care-gaps-03'
       description 'Server should return a 501 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -78,7 +80,7 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid subject'
       id 'care-gaps-04'
       description 'Server should return a 400 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -15,7 +15,7 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
+    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
 
     INVALID_ID = 'INVALID_ID'
 

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -15,6 +15,7 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
 
     INVALID_ID = 'INVALID_ID'
 
@@ -22,7 +23,7 @@ module DEQMTestKit
       title 'Check $care-gaps proper calculation'
       id 'care-gaps-01'
       description 'Server should properly return a gaps report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -41,7 +42,7 @@ module DEQMTestKit
       title 'Check $care-gaps missing required parameter'
       id 'care-gaps-02'
       description 'Server should return a 400 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_end, default: '2019-12-31'
 
@@ -59,7 +60,7 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid optional parameters'
       id 'care-gaps-03'
       description 'Server should return a 501 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -80,7 +81,7 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid subject'
       id 'care-gaps-04'
       description 'Server should return a 400 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'json'
+$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # tests for $care-gaps
@@ -18,30 +20,7 @@ module DEQMTestKit
       title 'Check $care-gaps proper calculation'
       id 'care-gaps-01'
       description 'Server should properly return a gaps report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -60,30 +39,7 @@ module DEQMTestKit
       title 'Check $care-gaps missing required parameter'
       id 'care-gaps-02'
       description 'Server should return a 400 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_end, default: '2019-12-31'
 
@@ -101,30 +57,7 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid optional parameters'
       id 'care-gaps-03'
       description 'Server should return a 501 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -144,31 +77,8 @@ module DEQMTestKit
     test do
       title 'Check $care-gaps with invalid subject'
       id 'care-gaps-04'
-      description 'Server should return a 404 response code'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      description 'Server should return a 400 response code'
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -179,7 +89,7 @@ module DEQMTestKit
                           '&status=open-gap&subject=INVALID'
         fhir_operation("/Measure/$care-gaps?#{invalid_subject}")
 
-        assert_response_status(404)
+        assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
         assert(resource.issue[0].severity == 'error')
@@ -188,7 +98,7 @@ module DEQMTestKit
     test do
       title 'Check $care-gaps with no measure identifier'
       id 'care-gaps-05'
-      description 'Server should return a 400 response code'
+      description 'Server should return a 200 response code'
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -197,10 +107,9 @@ module DEQMTestKit
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&status=open-gap"
         fhir_operation("/Measure/$care-gaps?#{params}")
 
-        assert_response_status(400)
+        assert_response_status(200)
+        assert_resource_type(:parameters)
         assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
       end
     end
     test do

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -18,7 +18,31 @@ module DEQMTestKit
       title 'Check $care-gaps proper calculation'
       id 'care-gaps-01'
       description 'Server should properly return a gaps report'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -36,7 +60,31 @@ module DEQMTestKit
       title 'Check $care-gaps missing required parameter'
       id 'care-gaps-02'
       description 'Server should return a 400 response code'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_end, default: '2019-12-31'
 
       run do
@@ -53,7 +101,31 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid optional parameters'
       id 'care-gaps-03'
       description 'Server should return a 501 response code'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -73,6 +145,30 @@ module DEQMTestKit
       title 'Check $care-gaps with invalid subject'
       id 'care-gaps-04'
       description 'Server should return a 404 response code'
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       input :measure_id, :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -21,7 +21,7 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
+    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
 
     PARAMS = {
       resourceType: 'Parameters',

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-
 require_relative '../utils/data_requirements_utils'
+require 'json'
+$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # GET [base]/Measure/CMS146/$data-requirements?periodStart=2014&periodEnd=2014
@@ -33,30 +34,7 @@ module DEQMTestKit
       description 'Data requirements on the fhir test server match the data requirements of our embedded client'
       makes_request :data_requirements
       output :queries_json
-      input :measure_id, type: 'radio', optional: false, options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
 
       run do
         # Get measure resource from client
@@ -114,30 +92,7 @@ module DEQMTestKit
       title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
       description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
-      input :measure_id, type: 'radio', optional: false, options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       run do
         # Run our data requirements operation on the test client server
         fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -33,7 +33,30 @@ module DEQMTestKit
       description 'Data requirements on the fhir test server match the data requirements of our embedded client'
       makes_request :data_requirements
       output :queries_json
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
 
       run do
         # Get measure resource from client
@@ -91,7 +114,30 @@ module DEQMTestKit
       title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
       description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       run do
         # Run our data requirements operation on the test client server
         fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -21,6 +21,7 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
 
     PARAMS = {
       resourceType: 'Parameters',
@@ -36,7 +37,7 @@ module DEQMTestKit
       description 'Data requirements on the fhir test server match the data requirements of our embedded client'
       makes_request :data_requirements
       output :queries_json
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
 
       run do
         # Get measure resource from client
@@ -94,7 +95,7 @@ module DEQMTestKit
       title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
       description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       run do
         # Run our data requirements operation on the test client server
         fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
+
 require_relative '../utils/data_requirements_utils'
 require 'json'
-$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # GET [base]/Measure/CMS146/$data-requirements?periodStart=2014&periodEnd=2014
@@ -20,6 +20,8 @@ module DEQMTestKit
       url 'http://cqf_ruler:8080/cqf-ruler-r4/fhir'
     end
 
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+
     PARAMS = {
       resourceType: 'Parameters',
       parameter: [{}]
@@ -34,7 +36,7 @@ module DEQMTestKit
       description 'Data requirements on the fhir test server match the data requirements of our embedded client'
       makes_request :data_requirements
       output :queries_json
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
 
       run do
         # Get measure resource from client
@@ -92,7 +94,7 @@ module DEQMTestKit
       title 'Check data requirements returns 400 for missing parameters'
       id 'data-requirements-02'
       description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       run do
         # Run our data requirements operation on the test client server
         fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -15,7 +15,7 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
+    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -15,6 +15,7 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
@@ -23,7 +24,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for individual report'
       id 'evaluate-measure-01'
       description 'Server should properly return an individual measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -44,7 +45,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for subject-list report'
       id 'evaluate-measure-02'
       description 'Server should properly return a subject-list measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -63,7 +64,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for population report'
       id 'evaluate-measure-03'
       description 'Server should properly return a population measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -101,7 +102,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid patient ID'
       id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given patient ID cannot be found'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -120,7 +121,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing required param'
       id 'evaluate-measure-06'
       description 'Request returns a 400 error for missing required param (periodStart)'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_end, default: '2019-12-31'
 
@@ -139,7 +140,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
       id 'evaluate-measure-07'
       description 'Request returns 400 for missing subject param when individual report type is specified'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -159,7 +160,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid reportType'
       id 'evaluate-measure-08'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -19,7 +19,31 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for individual report'
       id 'evaluate-measure-01'
       description 'Server should properly return an individual measure report'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -39,7 +63,30 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for subject-list report'
       id 'evaluate-measure-02'
       description 'Server should properly return a subject-list measure report'
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -58,7 +105,30 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for population report'
       id 'evaluate-measure-03'
       description 'Server should properly return a population measure report'
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -96,7 +166,30 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid patient ID'
       id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given patient ID cannot be found'
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -115,7 +208,31 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing required param'
       id 'evaluate-measure-06'
       description 'Request returns a 400 error for missing required param (periodStart)'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_end, default: '2019-12-31'
 
       run do
@@ -133,7 +250,31 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
       id 'evaluate-measure-07'
       description 'Request returns 400 for missing subject param when individual report type is specified'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -152,7 +293,31 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid reportType'
       id 'evaluate-measure-08'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
-      input :measure_id, :patient_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
+      input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
+
 require 'json'
-$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # tests for $evaluate-measure
@@ -14,6 +14,8 @@ module DEQMTestKit
       url :url
     end
 
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
 
@@ -21,7 +23,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for individual report'
       id 'evaluate-measure-01'
       description 'Server should properly return an individual measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -42,7 +44,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for subject-list report'
       id 'evaluate-measure-02'
       description 'Server should properly return a subject-list measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -61,7 +63,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for population report'
       id 'evaluate-measure-03'
       description 'Server should properly return a population measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -99,7 +101,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid patient ID'
       id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given patient ID cannot be found'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -118,7 +120,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing required param'
       id 'evaluate-measure-06'
       description 'Request returns a 400 error for missing required param (periodStart)'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_end, default: '2019-12-31'
 
@@ -137,7 +139,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
       id 'evaluate-measure-07'
       description 'Request returns 400 for missing subject param when individual report type is specified'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -157,7 +159,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid reportType'
       id 'evaluate-measure-08'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'json'
+$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # tests for $evaluate-measure
@@ -19,30 +21,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for individual report'
       id 'evaluate-measure-01'
       description 'Server should properly return an individual measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -63,30 +42,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for subject-list report'
       id 'evaluate-measure-02'
       description 'Server should properly return a subject-list measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -105,30 +61,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure proper calculation for population report'
       id 'evaluate-measure-03'
       description 'Server should properly return a population measure report'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -166,30 +99,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid patient ID'
       id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given patient ID cannot be found'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
@@ -208,30 +118,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing required param'
       id 'evaluate-measure-06'
       description 'Request returns a 400 error for missing required param (periodStart)'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_end, default: '2019-12-31'
 
@@ -250,30 +137,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
       id 'evaluate-measure-07'
       description 'Request returns 400 for missing subject param when individual report type is specified'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
@@ -293,30 +157,7 @@ module DEQMTestKit
       title 'Check $evaluate-measure fails for invalid reportType'
       id 'evaluate-measure-08'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module DEQMTestKit
   # MeasureAvailability test group ensures selected measures are available on the fhir server
   class MeasureAvailability < Inferno::TestGroup
@@ -10,6 +12,8 @@ module DEQMTestKit
     fhir_client do
       url :url
     end
+
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureAvailabilityRadioButton.json'))
     # rubocop:disable Metrics/BlockLength
     test do
       title 'Measure can be found'
@@ -17,30 +21,7 @@ module DEQMTestKit
       description 'Selected measure with matching id is available on the server and a valid json object'
       makes_request :measure_search
       input :selected_measure_id, type: 'radio', optional: false,
-                                  default: 'EXM130|7.3.000', options: {
-                                    list_options: [
-                                      {
-                                        label: 'EXM104',
-                                        value: 'EXM104|8.2.000'
-                                      },
-                                      {
-                                        label: 'EXM105',
-                                        value: 'EXM105|8.2.000'
-                                      },
-                                      {
-                                        label: 'EXM124',
-                                        value: 'EXM124|9.0.000'
-                                      },
-                                      {
-                                        label: 'EXM125',
-                                        value: 'EXM125|7.3.000'
-                                      },
-                                      {
-                                        label: 'EXM130',
-                                        value: 'EXM130|7.3.000'
-                                      }
-                                    ]
-                                  }
+                                  default: 'EXM130|7.3.000', options: measure_options
       output :measure_id
       run do
         # Look for matching measure from cqf-ruler datastore by resource id

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -14,9 +14,8 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureAvailabilityRadioButton.json'))
-    measure_id_args = {type: 'radio', optional: false, default: 'EXM130|7.3.000', options: measure_options}
+    measure_id_args = { type: 'radio', optional: false, default: 'EXM130|7.3.000', options: measure_options }
 
-    # rubocop:disable Metrics/BlockLength
     test do
       title 'Measure can be found'
       id 'measure-availability-01'
@@ -40,8 +39,6 @@ module DEQMTestKit
         output measure_id: resource.entry[0].resource.id
       end
     end
-    # rubocop:enable Metrics/BlockLength
-
     test do
       title 'Measure cannot be found returns empty bundle'
       id 'measure-availability-02'

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -11,19 +11,43 @@ module DEQMTestKit
       url :url
     end
 
-    MEASURES = ['EXM130|7.3.000', 'EXM125|7.3.000'].freeze
+    #MEASURES = ['EXM130|7.3.000', 'EXM125|7.3.000'].freeze
 
     test do
       title 'Measure can be found'
       id 'measure-availability-01'
       description 'Selected measure with matching id is available on the server and a valid json object'
       makes_request :measure_search
+      input :selected_measure_id, type: 'radio', optional: false, default: 'EXM130|7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'EXM104|8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'EXM105|8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'EXM124|9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'EXM125|7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'EXM130|7.3.000'
+          }
+        ]
+      }
       output :measure_id
 
       run do
         # Look for matching measure from cqf-ruler datastore by resource id
         # TODO: actually pull measure from user input drop down (populated from embedded client)
-        measure_to_test = MEASURES[0]
+        measure_to_test = selected_measure_id
         measure_identifier, measure_version = measure_to_test.split('|')
 
         # Search system for measure by identifier and version

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -10,38 +10,38 @@ module DEQMTestKit
     fhir_client do
       url :url
     end
-
+    # rubocop:disable Metrics/BlockLength
     test do
       title 'Measure can be found'
       id 'measure-availability-01'
       description 'Selected measure with matching id is available on the server and a valid json object'
       makes_request :measure_search
-      input :selected_measure_id, type: 'radio', optional: false, default: 'EXM130|7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'EXM104|8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'EXM105|8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'EXM124|9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'EXM125|7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'EXM130|7.3.000'
-          }
-        ]
-      }
+      input :selected_measure_id, type: 'radio', optional: false,
+                                  default: 'EXM130|7.3.000', options: {
+                                    list_options: [
+                                      {
+                                        label: 'EXM104',
+                                        value: 'EXM104|8.2.000'
+                                      },
+                                      {
+                                        label: 'EXM105',
+                                        value: 'EXM105|8.2.000'
+                                      },
+                                      {
+                                        label: 'EXM124',
+                                        value: 'EXM124|9.0.000'
+                                      },
+                                      {
+                                        label: 'EXM125',
+                                        value: 'EXM125|7.3.000'
+                                      },
+                                      {
+                                        label: 'EXM130',
+                                        value: 'EXM130|7.3.000'
+                                      }
+                                    ]
+                                  }
       output :measure_id
-
       run do
         # Look for matching measure from cqf-ruler datastore by resource id
         # TODO: actually pull measure from user input drop down (populated from embedded client)
@@ -58,6 +58,7 @@ module DEQMTestKit
         output measure_id: resource.entry[0].resource.id
       end
     end
+    # rubocop:enable Metrics/BlockLength
 
     test do
       title 'Measure cannot be found returns empty bundle'

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -14,14 +14,15 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureAvailabilityRadioButton.json'))
+    measure_id_args = {type: 'radio', optional: false, default: 'EXM130|7.3.000', options: measure_options}
+
     # rubocop:disable Metrics/BlockLength
     test do
       title 'Measure can be found'
       id 'measure-availability-01'
       description 'Selected measure with matching id is available on the server and a valid json object'
       makes_request :measure_search
-      input :selected_measure_id, type: 'radio', optional: false,
-                                  default: 'EXM130|7.3.000', options: measure_options
+      input :selected_measure_id, measure_id_args
       output :measure_id
       run do
         # Look for matching measure from cqf-ruler datastore by resource id

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -11,8 +11,6 @@ module DEQMTestKit
       url :url
     end
 
-    #MEASURES = ['EXM130|7.3.000', 'EXM125|7.3.000'].freeze
-
     test do
       title 'Measure can be found'
       id 'measure-availability-01'

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require 'json'
+$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # Perform submit data operation on test client
@@ -26,30 +28,7 @@ module DEQMTestKit
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'
       makes_request :submit_data
       input :queries_json
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
 
       run do
         # get measure from client
@@ -141,30 +120,7 @@ module DEQMTestKit
       title 'Fails if a measureReport is not submitted'
       id 'submit-data-02'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       run do
         test_measure = FHIR::Measure.new(id: measure_id)
 
@@ -190,30 +146,7 @@ module DEQMTestKit
       title 'Fails if multiple measureReports are submitted'
       id 'submit-data-03'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
-        list_options: [
-          {
-            label: 'EXM104',
-            value: 'measure-EXM104-8.2.000'
-          },
-          {
-            label: 'EXM105',
-            value: 'measure-EXM105-8.2.000'
-          },
-          {
-            label: 'EXM124',
-            value: 'measure-EXM124-9.0.000'
-          },
-          {
-            label: 'EXM125',
-            value: 'measure-EXM125-7.3.000'
-          },
-          {
-            label: 'EXM130',
-            value: 'measure-EXM130-7.3.000'
-          }
-        ]
-      }
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
       run do
         assert(measure_id,
                'No measure selected. Run Measure Availability prior to running the Submit Data test group.')

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -11,6 +11,7 @@ module DEQMTestKit
     description 'Ensure fhir server can receive data via the $submit-data operation'
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}' }
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
 
     fhir_client do
       url :url
@@ -28,7 +29,7 @@ module DEQMTestKit
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'
       makes_request :submit_data
       input :queries_json
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
 
       run do
         # get measure from client
@@ -120,7 +121,7 @@ module DEQMTestKit
       title 'Fails if a measureReport is not submitted'
       id 'submit-data-02'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       run do
         test_measure = FHIR::Measure.new(id: measure_id)
 
@@ -146,7 +147,7 @@ module DEQMTestKit
       title 'Fails if multiple measureReports are submitted'
       id 'submit-data-03'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
+      input :measure_id, measure_id_args
       run do
         assert(measure_id,
                'No measure selected. Run Measure Availability prior to running the Submit Data test group.')

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -11,7 +11,7 @@ module DEQMTestKit
     description 'Ensure fhir server can receive data via the $submit-data operation'
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}' }
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = {type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options}
+    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
 
     fhir_client do
       url :url

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -2,7 +2,6 @@
 
 require 'securerandom'
 require 'json'
-$measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
 module DEQMTestKit
   # Perform submit data operation on test client
@@ -11,6 +10,7 @@ module DEQMTestKit
     title 'Submit Data'
     description 'Ensure fhir server can receive data via the $submit-data operation'
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}' }
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
 
     fhir_client do
       url :url
@@ -28,7 +28,7 @@ module DEQMTestKit
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'
       makes_request :submit_data
       input :queries_json
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
 
       run do
         # get measure from client
@@ -120,7 +120,7 @@ module DEQMTestKit
       title 'Fails if a measureReport is not submitted'
       id 'submit-data-02'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       run do
         test_measure = FHIR::Measure.new(id: measure_id)
 
@@ -146,7 +146,7 @@ module DEQMTestKit
       title 'Fails if multiple measureReports are submitted'
       id 'submit-data-03'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
-      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: $measure_options
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options
       run do
         assert(measure_id,
                'No measure selected. Run Measure Availability prior to running the Submit Data test group.')

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -26,7 +26,30 @@ module DEQMTestKit
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'
       makes_request :submit_data
       input :queries_json
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
 
       run do
         # get measure from client
@@ -118,7 +141,30 @@ module DEQMTestKit
       title 'Fails if a measureReport is not submitted'
       id 'submit-data-02'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       run do
         test_measure = FHIR::Measure.new(id: measure_id)
 
@@ -144,7 +190,30 @@ module DEQMTestKit
       title 'Fails if multiple measureReports are submitted'
       id 'submit-data-03'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
-      input :measure_id
+      input :measure_id, type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: {
+        list_options: [
+          {
+            label: 'EXM104',
+            value: 'measure-EXM104-8.2.000'
+          },
+          {
+            label: 'EXM105',
+            value: 'measure-EXM105-8.2.000'
+          },
+          {
+            label: 'EXM124',
+            value: 'measure-EXM124-9.0.000'
+          },
+          {
+            label: 'EXM125',
+            value: 'measure-EXM125-7.3.000'
+          },
+          {
+            label: 'EXM130',
+            value: 'measure-EXM130-7.3.000'
+          }
+        ]
+      }
       run do
         assert(measure_id,
                'No measure selected. Run Measure Availability prior to running the Submit Data test group.')

--- a/lib/fixtures/measureAvailabilityRadioButton.json
+++ b/lib/fixtures/measureAvailabilityRadioButton.json
@@ -1,0 +1,24 @@
+{
+  "list_options": [
+    {
+      "label": "EXM104",
+      "value": "EXM104|8.2.000"
+    },
+    {
+      "label": "EXM105",
+      "value": "EXM105|8.2.000"
+    },
+    {
+      "label": "EXM124",
+      "value": "EXM124|9.0.000"
+    },
+    {
+      "label": "EXM125",
+      "value": "EXM125|7.3.000"
+    },
+    {
+      "label": "EXM130",
+      "value": "EXM130|7.3.000"
+    }
+  ]
+}

--- a/lib/fixtures/measureRadioButton.json
+++ b/lib/fixtures/measureRadioButton.json
@@ -1,0 +1,24 @@
+{
+  "list_options": [
+    {
+      "label": "EXM104",
+      "value": "measure-EXM104-8.2.000"
+    },
+    {
+      "label": "EXM105",
+      "value": "measure-EXM105-8.2.000"
+    },
+    {
+      "label": "EXM124",
+      "value": "measure-EXM124-9.0.000"
+    },
+    {
+      "label": "EXM125",
+      "value": "measure-EXM125-7.3.000"
+    },
+    {
+      "label": "EXM130",
+      "value": "measure-EXM130-7.3.000"
+    }
+  ]
+}

--- a/spec/deqm_test_kit/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/care_gaps_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe DEQMTestKit::CareGaps do
       "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
         "&subject=#{patient_id}&status=open-gap"
     end
-    let(:no_measure_params) do
-      "periodStart=#{period_start}&periodEnd=#{period_end}"\
-        "&subject=#{patient_id}&status=open-gap"
-    end
     test_parameters = FHIR::Parameters.new(total: 1)
     it 'passes if request has valid parameters, patient id, and measure id' do
       stub_request(
@@ -62,15 +58,6 @@ RSpec.describe DEQMTestKit::CareGaps do
                          period_end: period_end)
       expect(result.result).to eq('fail')
     end
-    # it 'passes if request has valid parameters and patient id without measure id' do
-    #   stub_request(
-    #     :post,
-    #     "#{url}/Measure/$care-gaps?#{no_measure_params}"
-    #   ).to_return(status: 200, body: test_parameters.to_json)
-    #   result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-    #                      period_end: period_end)
-    #   expect(result.result).to eq('pass')
-    # end
   end
   describe '$care-gaps missing required parameter test' do
     let(:test) { group.tests[1] }
@@ -188,6 +175,28 @@ RSpec.describe DEQMTestKit::CareGaps do
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
                          period_end: period_end)
       expect(result.result).to eq('fail')
+    end
+  end
+  describe '$care-gaps successful test with no measure identifier' do
+    let(:test) { group.tests[4] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'Patient/numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:test_parameters) { FHIR::Parameters.new(total: 1) }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+    let(:params) do
+      "periodStart=#{period_start}&periodEnd=#{period_end}"\
+        "&subject=#{patient_id}&status=open-gap"
+    end
+    it 'passes if request has valid parameters and patient id without measure id' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: test_parameters.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('pass')
     end
   end
   describe '$care-gaps has invalid measure id test' do

--- a/spec/deqm_test_kit/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/care_gaps_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   describe '$care-gaps successful test' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'numer-EXM130' }
+    let(:patient_id) { 'Patient/numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
     let(:test_parameters) { FHIR::Parameters.new(total: 1) }
@@ -28,6 +28,10 @@ RSpec.describe DEQMTestKit::CareGaps do
 
     let(:params) do
       "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
+        "&subject=#{patient_id}&status=open-gap"
+    end
+    let(:no_measure_params) do
+      "periodStart=#{period_start}&periodEnd=#{period_end}"\
         "&subject=#{patient_id}&status=open-gap"
     end
     test_parameters = FHIR::Parameters.new(total: 1)
@@ -40,7 +44,6 @@ RSpec.describe DEQMTestKit::CareGaps do
                          period_end: period_end)
       expect(result.result).to eq('pass')
     end
-
     it 'passes if request has valid parameters, patient id, and measure id' do
       stub_request(
         :post,
@@ -59,6 +62,15 @@ RSpec.describe DEQMTestKit::CareGaps do
                          period_end: period_end)
       expect(result.result).to eq('fail')
     end
+    # it 'passes if request has valid parameters and patient id without measure id' do
+    #   stub_request(
+    #     :post,
+    #     "#{url}/Measure/$care-gaps?#{no_measure_params}"
+    #   ).to_return(status: 200, body: test_parameters.to_json)
+    #   result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+    #                      period_end: period_end)
+    #   expect(result.result).to eq('pass')
+    # end
   end
   describe '$care-gaps missing required parameter test' do
     let(:test) { group.tests[1] }
@@ -150,45 +162,6 @@ RSpec.describe DEQMTestKit::CareGaps do
     let(:params) do
       "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}&status=open-gap&subject=INVALID"
     end
-    it 'passes if request returns 404 with OperationOutcome' do
-      stub_request(
-        :post,
-        "#{url}/Measure/$care-gaps?#{params}"
-      ).to_return(status: 404, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('pass')
-    end
-    it 'fails if request returns 200' do
-      stub_request(
-        :post,
-        "#{url}/Measure/$care-gaps?#{params}"
-      ).to_return(status: 200, body: error_outcome.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('fail')
-    end
-    it 'fails if request returns a parameters object' do
-      stub_request(
-        :post,
-        "#{url}/Measure/$care-gaps?#{params}"
-      ).to_return(status: 404, body: test_parameters.to_json)
-      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
-                         period_end: period_end)
-      expect(result.result).to eq('fail')
-    end
-  end
-  describe '$care-gaps has missing measure identifier test' do
-    let(:test) { group.tests[4] }
-    let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'numer-EXM130' }
-    let(:period_start) { '2019-01-01' }
-    let(:period_end) { '2019-12-31' }
-    let(:test_parameters) { FHIR::Parameters.new(total: 1) }
-    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-    let(:params) do
-      "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&status=open-gap"
-    end
     it 'passes if request returns 400 with OperationOutcome' do
       stub_request(
         :post,
@@ -211,7 +184,7 @@ RSpec.describe DEQMTestKit::CareGaps do
       stub_request(
         :post,
         "#{url}/Measure/$care-gaps?#{params}"
-      ).to_return(status: 400, body: test_parameters.to_json)
+      ).to_return(status: 404, body: test_parameters.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
                          period_end: period_end)
       expect(result.result).to eq('fail')

--- a/spec/deqm_test_kit/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/measure_availability_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
     let(:test) { group.tests.first }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
+    let(:selected_measure_id) { 'EXM130|7.3.000' }
 
     it 'passes if a Measure was received' do
       resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])
@@ -29,7 +30,7 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
         .to_return(status: 200, body: resource.to_json)
 
       # TODO: pass in measure information once it is a measure_availability group input (and in below runs)
-      result = run(test, url: url)
+      result = run(test, selected_measure_id: selected_measure_id, url: url)
 
       expect(result.result).to eq('pass')
     end
@@ -39,7 +40,7 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 201, body: resource.to_json)
 
-      result = run(test, url: url)
+      result = run(test, selected_measure_id: selected_measure_id, url: url)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(/200/)
@@ -50,7 +51,7 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
       stub_request(:get, "#{url}/Measure?name=#{measure_name}&version=#{measure_version}")
         .to_return(status: 200, body: resource.to_json)
 
-      result = run(test, url: url)
+      result = run(test, selected_measure_id: selected_measure_id, url: url)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(/measure/)


### PR DESCRIPTION
# Summary
This PR implements radio button selection for measure IDs in the test kit.

## New behavior
Previously, we had to hard-code the EXM130 measure for all the tests. The Inferno-core 0.1.X update adds the ability to specify a radio button input. Now, when running the tests, the user will be able to select a measure from the list of options. The radio button input defaults to the EXM130 measure.

## Code changes
For each of the tests that require a measure ID as input, the measure ID is now specified to be of type `radio`, is defaulted to have the EXM130 measure ID for the default value, and contains value options for the following measures: EXM104, EXM105, EXM124, EXM125, and EXM130. The fixture `measureRadioButton.json` contains the label/value pairs for the radio buttons.

The code for the radio button inputs was inspired by some of the code additions in this [Inferno-Core PR](https://github.com/inferno-framework/inferno-core/pull/70).

Some small changes were also made to the care gaps tests to reflect recent updates in `deqm-test-server`.

# Testing guidance 
All tests can be run using the rspec command. To run the application, make sure you have docker running, then run the commands `docker-compose pull` followed by `docker-compose up --build`. Navigate to `http://localhost:4567 `and select the test suite. 

Try running the tests with different measures. To access some of the newly available measure options, you may need to run `docker-compose up` and then POST the desired measure to `http://localhost:3000/4_0_1/`. Otherwise, the measure availability will fail, and all other tests that require the measure will fail.

Note that some tests are expected to fail right now, such as the `evaluate-measure` subject-list test and the bulk submit data test. Also note that some of the care gaps tests may fail and throw a 400 error if the patient ID format is not `Patient/<id>` or `Group/<id>`.