### PR TITLE
Testing for Group Subject Functionality

### DIFF
--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -43,7 +43,6 @@ module DEQMTestKit
       id 'care-gaps-02'
       description 'Server should properly return a gaps report'
       input :measure_id, measure_id_args
-      input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
       input :group_id

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -30,7 +30,27 @@ module DEQMTestKit
 
       run do
         params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
-                 "&subject=#{patient_id}&status=open-gap"
+                 "&subject=Patient/#{patient_id}&status=open-gap"
+        fhir_operation("/Measure/$care-gaps?#{params}")
+
+        assert_response_status(200)
+        assert_resource_type(:parameters)
+        assert_valid_json(response[:body])
+      end
+    end
+    test do
+      title 'Check $care-gaps proper calculation for Group subject'
+      id 'care-gaps-02'
+      description 'Server should properly return a gaps report'
+      input :measure_id, measure_id_args
+      input :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+      input :group_id
+
+      run do
+        params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
+                 "&subject=Group/#{group_id}&status=open-gap"
         fhir_operation("/Measure/$care-gaps?#{params}")
 
         assert_response_status(200)
@@ -40,14 +60,14 @@ module DEQMTestKit
     end
     test do
       title 'Check $care-gaps missing required parameter'
-      id 'care-gaps-02'
+      id 'care-gaps-03'
       description 'Server should return a 400 response code'
       input :measure_id, measure_id_args
       input :patient_id
       input :period_end, default: '2019-12-31'
 
       run do
-        invalid_params = "measureId=#{measure_id}&periodEnd=#{period_end}&subject=#{patient_id}&status=open-gap"
+        invalid_params = "measureId=#{measure_id}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&status=open-gap"
         fhir_operation("/Measure/$care-gaps?#{invalid_params}")
 
         assert_response_status(400)
@@ -57,9 +77,9 @@ module DEQMTestKit
       end
     end
     test do
-      title 'Check $care-gaps with invalid optional parameters'
-      id 'care-gaps-03'
-      description 'Server should return a 501 response code'
+      title 'Check $care-gaps with subject and organization'
+      id 'care-gaps-04'
+      description 'Server should return a 400 response code'
       input :measure_id, measure_id_args
       input :patient_id
       input :period_start, default: '2019-01-01'
@@ -68,10 +88,10 @@ module DEQMTestKit
       run do
         # A request with invalid practitioner and organization ids
         invalid_optional = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
-                           "&subject=#{patient_id}&status=open-gap&practitioner=INVALID&organization=INVALID"
+                           "&subject=Patient/#{patient_id}&status=open-gap&organization=Organization/testOrganization"
         fhir_operation("/Measure/$care-gaps?#{invalid_optional}")
 
-        assert_response_status(501)
+        assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
         assert(resource.issue[0].severity == 'error')
@@ -79,7 +99,7 @@ module DEQMTestKit
     end
     test do
       title 'Check $care-gaps with invalid subject'
-      id 'care-gaps-04'
+      id 'care-gaps-05'
       description 'Server should return a 400 response code'
       input :measure_id, measure_id_args
       input :measure_id, :patient_id
@@ -100,14 +120,14 @@ module DEQMTestKit
     end
     test do
       title 'Check $care-gaps with no measure identifier'
-      id 'care-gaps-05'
+      id 'care-gaps-06'
       description 'Server should return a 200 response code'
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&status=open-gap"
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&status=open-gap"
         fhir_operation("/Measure/$care-gaps?#{params}")
 
         assert_response_status(200)
@@ -117,7 +137,7 @@ module DEQMTestKit
     end
     test do
       title 'Check $care-gaps with invalid measure id'
-      id 'care-gaps-06'
+      id 'care-gaps-07'
       description 'Server should return a 404 response code'
       input :patient_id
       input :period_start, default: '2019-01-01'
@@ -125,7 +145,7 @@ module DEQMTestKit
 
       run do
         params = "measureId=INVALID_MEASURE&periodStart=#{period_start}&periodEnd=#{period_end}"\
-                 "&subject=#{patient_id}&status=open-gap"
+                 "&subject=Patient/#{patient_id}&status=open-gap"
         fhir_operation("/Measure/$care-gaps?#{params}")
 
         assert_response_status(404)

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -30,7 +30,7 @@ module DEQMTestKit
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}"
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
         assert_response_status(200)
@@ -78,17 +78,35 @@ module DEQMTestKit
         assert(resource.type == 'summary')
       end
     end
+    test do
+      title 'Check $evaluate-measure proper calculation for population report with group subject'
+      id 'evaluate-measure-04'
+      description 'Server should properly return a population measure report'
+      input :measure_id, measure_id_args
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+      input :group_id
 
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=population&subject=Group/#{group_id}"
+        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+
+        assert_response_status(200)
+        assert_resource_type(:measure_report)
+        assert_valid_json(response[:body])
+        assert(resource.type == 'summary')
+      end
+    end
     test do
       title 'Check $evaluate-measure fails for invalid measure ID'
-      id 'evaluate-measure-04'
+      id 'evaluate-measure-05'
       description 'Request returns a 404 error when the given measure ID cannot be found'
       input :patient_id
       input :period_start, default: '2019-01-01'
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}"
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}"
         fhir_operation("/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}")
 
         assert_response_status(404)
@@ -100,7 +118,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for invalid patient ID'
-      id 'evaluate-measure-05'
+      id 'evaluate-measure-06'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id, measure_id_args
       input :period_start, default: '2019-01-01'
@@ -119,14 +137,14 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for missing required param'
-      id 'evaluate-measure-06'
+      id 'evaluate-measure-07'
       description 'Request returns a 400 error for missing required param (periodStart)'
       input :measure_id, measure_id_args
       input :patient_id
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodEnd=#{period_end}&subject=#{patient_id}"
+        params = "periodEnd=#{period_end}&subject=Patient/#{patient_id}"
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
         assert_response_status(400)
@@ -138,7 +156,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for missing subject param (individual report type)'
-      id 'evaluate-measure-07'
+      id 'evaluate-measure-08'
       description 'Request returns 400 for missing subject param when individual report type is specified'
       input :measure_id, measure_id_args
       input :patient_id
@@ -158,7 +176,7 @@ module DEQMTestKit
 
     test do
       title 'Check $evaluate-measure fails for invalid reportType'
-      id 'evaluate-measure-08'
+      id 'evaluate-measure-09'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, measure_id_args
       input :patient_id
@@ -166,7 +184,7 @@ module DEQMTestKit
       input :period_end, default: '2019-12-31'
 
       run do
-        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=#{patient_id}&reportType=INVALID"
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&reportType=INVALID"
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
         assert_response_status(400)

--- a/spec/deqm_test_kit/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/care_gaps_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   describe '$care-gaps successful test' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'Patient/numer-EXM130' }
+    let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
     let(:test_parameters) { FHIR::Parameters.new(total: 1) }
@@ -28,7 +28,7 @@ RSpec.describe DEQMTestKit::CareGaps do
 
     let(:params) do
       "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
-        "&subject=#{patient_id}&status=open-gap"
+        "&subject=Patient/#{patient_id}&status=open-gap"
     end
     test_parameters = FHIR::Parameters.new(total: 1)
     it 'passes if request has valid parameters, patient id, and measure id' do
@@ -59,8 +59,52 @@ RSpec.describe DEQMTestKit::CareGaps do
       expect(result.result).to eq('fail')
     end
   end
-  describe '$care-gaps missing required parameter test' do
+
+  describe '$care-gaps successful test with Group subject' do
     let(:test) { group.tests[1] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:group_id) { 'EXM130-patients' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:test_parameters) { FHIR::Parameters.new(total: 1) }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    let(:params) do
+      "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
+        "&subject=Group/#{group_id}&status=open-gap"
+    end
+    test_parameters = FHIR::Parameters.new(total: 1)
+    it 'passes if request has valid parameters' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: test_parameters.to_json)
+      result = run(test, url: url, measure_id: measure_id, group_id: group_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails if $care-gaps does not return 200' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 400, body: test_parameters.to_json)
+      result = run(test, url: url, measure_id: measure_id, group_id: group_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails if $care-gaps does not return Parameters object' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, group_id: group_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+    end
+  end
+  describe '$care-gaps missing required parameter test' do
+    let(:test) { group.tests[2] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -68,7 +112,7 @@ RSpec.describe DEQMTestKit::CareGaps do
     let(:test_parameters) { FHIR::Parameters.new(total: 1) }
     let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
     let(:params) do
-      "measureId=#{measure_id}&periodEnd=#{period_end}&subject=#{patient_id}&status=open-gap"
+      "measureId=#{measure_id}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&status=open-gap"
     end
     it 'passes if request returns 400 with OperationOutcome' do
       stub_request(
@@ -98,8 +142,8 @@ RSpec.describe DEQMTestKit::CareGaps do
       expect(result.result).to eq('fail')
     end
   end
-  describe '$care-gaps has invalid optional parameters test' do
-    let(:test) { group.tests[2] }
+  describe '$care-gaps has subject and organization test' do
+    let(:test) { group.tests[3] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -108,13 +152,13 @@ RSpec.describe DEQMTestKit::CareGaps do
     let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
     let(:params) do
       "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
-        "&status=open-gap&practitioner=INVALID&organization=INVALID&subject=#{patient_id}"
+        "&status=open-gap&organization=Organization/testOrganization&subject=Patient/#{patient_id}"
     end
-    it 'passes if request returns 501 with OperationOutcome' do
+    it 'passes if request returns 400 with OperationOutcome' do
       stub_request(
         :post,
         "#{url}/Measure/$care-gaps?#{params}"
-      ).to_return(status: 501, body: error_outcome.to_json)
+      ).to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
                          period_end: period_end)
       expect(result.result).to eq('pass')
@@ -139,7 +183,7 @@ RSpec.describe DEQMTestKit::CareGaps do
     end
   end
   describe '$care-gaps has invalid subject test' do
-    let(:test) { group.tests[3] }
+    let(:test) { group.tests[4] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -178,16 +222,16 @@ RSpec.describe DEQMTestKit::CareGaps do
     end
   end
   describe '$care-gaps successful test with no measure identifier' do
-    let(:test) { group.tests[4] }
+    let(:test) { group.tests[5] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:patient_id) { 'Patient/numer-EXM130' }
+    let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
     let(:test_parameters) { FHIR::Parameters.new(total: 1) }
     let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
     let(:params) do
       "periodStart=#{period_start}&periodEnd=#{period_end}"\
-        "&subject=#{patient_id}&status=open-gap"
+        "&subject=Patient/#{patient_id}&status=open-gap"
     end
     it 'passes if request has valid parameters and patient id without measure id' do
       stub_request(
@@ -200,7 +244,7 @@ RSpec.describe DEQMTestKit::CareGaps do
     end
   end
   describe '$care-gaps has invalid measure id test' do
-    let(:test) { group.tests[5] }
+    let(:test) { group.tests[6] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -209,7 +253,7 @@ RSpec.describe DEQMTestKit::CareGaps do
     let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
     let(:params) do
       "measureId=INVALID_MEASURE&periodStart=#{period_start}&periodEnd=#{period_end}"\
-        "&subject=#{patient_id}&status=open-gap"
+        "&subject=Patient/#{patient_id}&status=open-gap"
     end
     it 'passes if request returns 400 with OperationOutcome' do
       stub_request(

--- a/spec/deqm_test_kit/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/care_gaps_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DEQMTestKit::CareGaps do
                          period_end: period_end)
       expect(result.result).to eq('pass')
     end
-    it 'passes if request has valid parameters, patient id, and measure id' do
+    it 'fails if $care-gaps does not return 200' do
       stub_request(
         :post,
         "#{url}/Measure/$care-gaps?#{params}"
@@ -49,11 +49,11 @@ RSpec.describe DEQMTestKit::CareGaps do
                          period_end: period_end)
       expect(result.result).to eq('fail')
     end
-    it 'passes if request has valid parameters, patient id, and measure id' do
+    it 'fails if $care-gaps does not return a Parameters object' do
       stub_request(
         :post,
         "#{url}/Measure/$care-gaps?#{params}"
-      ).to_return(status: 400, body: error_outcome.to_json)
+      ).to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
                          period_end: period_end)
       expect(result.result).to eq('fail')

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -59,8 +59,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     let(:params) { "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=subject-list" }
 
     it 'passes for valid subject-list report' do
+      # rubocop:disable Layout/LineLength
       test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
                                                                           measure: measure_id } }], type: 'subject-list')
+      # rubocop:enable Layout/LineLength
+
       stub_request(
         :post,
         "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
@@ -169,8 +172,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
 
     it 'fails if $evaluate-measure does not return MeasureReport of type summary' do
+      # rubocop:disable Layout/LineLength
+
       test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
                                                                           measure: measure_id } }], type: 'subject-list')
+      # rubocop:enable Layout/LineLength
       stub_request(
         :post,
         "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"


### PR DESCRIPTION
# Summary
Added testing in $evaluate-measure and $care-gaps suites for new group subject functionality

## New behavior
The test kit will now run suites to check that the server under test can appropriately handle a subject of the form Group/Id

## Code changes
- Added test for group subject functionality in $care-gaps
- Added test for group subject functionality in $evaluate-measure
- Added rspec testing for new tests
- Updated existing issues in $care-gaps and $evaluate-measure files

# Testing guidance
- Run rspec tests using `rspec`
- Run `docker-compose up --build`
- After the server starts up, send a `PUT` request in Insomnia to `http://localhost:3000/4_0_1/Group/EXM130-patients`, with the following body
```
{ 
  "resourceType": "Group", 
  "id": "EXM130-patients", 
  "type": "person", 
  "actual": "true", 
  "member": [
    {
      "entity": { 
        "reference": "Patient/denom-EXM130" 
      } 
    }, 
    {
      "entity": {
        "reference": "Patient/numer-EXM130"
      }
    }
  ] 
}
```
- Navigate to [http://localhost:4567](http://localhost:4567)
- Run the $care-gaps and $evaluate-measure suites using `EXM130-patients` as the group id
- The tests should pass!
