### PR TITLE
Add tests for program, practitioner, organization to the care gaps tests

### DIFF
--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -153,6 +153,44 @@ module DEQMTestKit
         assert(resource.issue[0].severity == 'error')
       end
     end
+    test do
+      title 'Check $care-gaps proper calculation with practitioner and organization parameters'
+      id 'care-gaps-08'
+      description 'Server should properly return a gaps report for request with practitioner and organization'
+      input :measure_id, measure_id_args
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+      input :practitioner_id
+      input :org_id
+
+      run do
+        params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
+                 "&status=open-gap&practitioner=Practitioner/#{practitioner_id}&organization=Organization/#{org_id}"
+        fhir_operation("/Measure/$care-gaps?#{params}")
+
+        assert_response_status(200)
+        assert_resource_type(:parameters)
+        assert_valid_json(response[:body])
+      end
+    end
+    test do
+      title 'Check $care-gaps proper calculation with program parameter'
+      id 'care-gaps-09'
+      description 'Server should properly return a gaps report for request with program'
+      input :patient_id
+      input :period_start, default: '2019-01-01'
+      input :period_end, default: '2019-12-31'
+
+      run do
+        params = "periodStart=#{period_start}&periodEnd=#{period_end}"\
+                 "&subject=Patient/#{patient_id}&status=open-gap&program=eligible-provider"
+        fhir_operation("/Measure/$care-gaps?#{params}")
+
+        assert_response_status(200)
+        assert_resource_type(:parameters)
+        assert_valid_json(response[:body])
+      end
+    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/spec/deqm_test_kit/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/care_gaps_spec.rb
@@ -283,4 +283,88 @@ RSpec.describe DEQMTestKit::CareGaps do
       expect(result.result).to eq('fail')
     end
   end
+  describe '$care-gaps successful test with practitioner and organization' do
+    let(:test) { group.tests[7] }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:practitioner_id) { '1' }
+    let(:org_id) { '1' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:test_parameters) { FHIR::Parameters.new(total: 1) }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    let(:params) do
+      "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}"\
+        "&practitioner=Practitioner/#{practitioner_id}&organization=Organization/#{org_id}&status=open-gap"
+    end
+    test_parameters = FHIR::Parameters.new(total: 1)
+    it 'passes if request has valid parameters' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: test_parameters.to_json)
+      result = run(test, url: url, measure_id: measure_id, practitioner_id: practitioner_id, org_id: org_id,
+                         period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails if $care-gaps does not return 200' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 400, body: test_parameters.to_json)
+      result = run(test, url: url, measure_id: measure_id, practitioner_id: practitioner_id, org_id: org_id,
+                         period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails if $care-gaps does not return Parameters object' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, measure_id: measure_id, practitioner_id: practitioner_id, org_id: org_id,
+                         period_start: period_start, period_end: period_end)
+      expect(result.result).to eq('fail')
+    end
+  end
+  describe '$care-gaps successful test with program' do
+    let(:test) { group.tests[8] }
+    let(:patient_id) { 'numer-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:test_parameters) { FHIR::Parameters.new(total: 1) }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    let(:params) do
+      "program=eligible-provider&periodStart=#{period_start}&periodEnd=#{period_end}"\
+        "&subject=Patient/#{patient_id}&status=open-gap"
+    end
+    test_parameters = FHIR::Parameters.new(total: 1)
+    it 'passes if request has valid parameters' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: test_parameters.to_json)
+      result = run(test, url: url, program: 'eligible-provider', patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails if $care-gaps does not return 200' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 400, body: test_parameters.to_json)
+      result = run(test, url: url, program: 'eligible-provider', patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+    end
+    it 'fails if $care-gaps does not return Parameters object' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$care-gaps?#{params}"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url: url, program: 'eligible-provider', patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('fail')
+    end
+  end
 end


### PR DESCRIPTION
# Summary
Adds two new tests to the care gap suite to ensure the support of program and of practitioner w/ organization parameters.

## New behavior
The test kit will now run tests to check that the server under test can appropriately handle a `program={name}` parameter instead of a measure parameter, and `organization=Organization/{id}` w/ `practitioner=Practitioner/{id}` parameters instead of subject parameter.

## Code changes
- Added tests for program and practitioner/organization parameters for the $care-gaps operation
- Added rspec testing for new tests

# Testing guidance
(may need to `docker-compose pull` and/or `bundle install` if the below don't work, depending on how up to date your system already is)
- Run rspec tests using `rspec`
- Run `docker-compose up --build`
- After the server starts up, these are the following insomnia/postman requests required to run all care-gaps tests:
`PUT` to `http://localhost:3000/4_0_1/Group/EXM130-patients`, with the following body
```
{ 
  "resourceType": "Group", 
  "id": "EXM130-patients", 
  "type": "person", 
  "actual": "true", 
  "member": [
    {
      "entity": { 
        "reference": "Patient/denom-EXM130" 
      } 
    }, 
    {
      "entity": {
        "reference": "Patient/numer-EXM130"
      }
    }
  ] 
}
```
`PUT` to `http://localhost:3000/4_0_1/Organization/1`, with the following body
```
{
"resourceType": "Organization",
"id": "1"
}
```
`PUT` to `http://localhost:3000/4_0_1/Practitioner/1`, with the following body
```
{
"resourceType": "Practitioner",
"id": "1"
}
```
`PUT` to `http://localhost:3000/4_0_1/Patient/denom-EXM130`, with the following body
```
{
	"resourceType": "Patient",
	"id": "denom-EXM130",
	"managingOrganization": {
		"reference": "Organization/1"
	},
	"generalPractitioner": {
		"reference": "Practitioner/1"
	}
	
}
```
- Navigate to [http://localhost:4567](http://localhost:4567)
- Run the care-gaps suite using the following parameters:
<img width="530" alt="Screen Shot 2022-03-29 at 10 55 49 AM" src="https://user-images.githubusercontent.com/2643955/160655700-5873a7da-fc2d-4f90-b2d6-55866788e8ee.png">
- All care gaps tests should pass
