### PR TITLE
Added FHIR Query from Data Requirements Suite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3"
 services:
   inferno:
+    stdin_open: true
+    tty: true
     build:
       context: ./
     volumes:
@@ -9,10 +11,10 @@ services:
       - "4567:4567"
     depends_on:
       - validator_service
-  cqf_ruler:
-    image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
-    ports:
-      - "8080:8080"
+  # cqf_ruler:
+  #   image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
+  #   ports:
+  #     - "8080:8080"
   validator_service:
     image: infernocommunity/fhir-validator-service:latest
     # Update this path to match your directory structure
@@ -40,6 +42,8 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   worker:
+    stdin_open: true
+    tty: true
     build:
       context: ./
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,6 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   worker:
-    stdin_open: true
-    tty: true
     build:
       context: ./
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 version: "3"
 services:
   inferno:
-    stdin_open: true
-    tty: true
     build:
       context: ./
     volumes:
@@ -11,10 +9,10 @@ services:
       - "4567:4567"
     depends_on:
       - validator_service
-  # cqf_ruler:
-  #   image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
-  #   ports:
-  #     - "8080:8080"
+  cqf_ruler:
+    image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
+    ports:
+      - "8080:8080"
   validator_service:
     image: infernocommunity/fhir-validator-service:latest
     # Update this path to match your directory structure

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -4,6 +4,7 @@ require_relative 'deqm_test_kit/patient_everything'
 require_relative 'deqm_test_kit/measure_availability'
 require_relative 'deqm_test_kit/data_requirements'
 require_relative 'deqm_test_kit/submit_data'
+require_relative 'deqm_test_kit/fhir_queries'
 require_relative 'deqm_test_kit/bulk_submit_data'
 require_relative 'deqm_test_kit/bulk_import'
 require_relative 'deqm_test_kit/evaluate_measure'
@@ -47,6 +48,7 @@ module DEQMTestKit
     # using their id
     group from: :measure_availability
     group from: :data_requirements
+    group from: :fhir_queries
     group from: :submit_data
     group from: :evaluate_measure
     group from: :care_gaps

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -10,7 +10,7 @@ module DEQMTestKit
     include DataRequirementsUtils
     id 'fhir_queries'
     title 'FHIR Queries'
-    description 'Ensure fhir server can handle queries resulting from $data-requirements operation'
+    description 'Ensure FHIR server can handle queries resulting from $data-requirements operation'
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
     measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000',
                         options: measure_options }
@@ -33,7 +33,7 @@ module DEQMTestKit
 
       run do
         assert(measure_id,
-               'No measure selected. Run Measure Availability prior to running the Submit Data test group.')
+               'No measure selected. Run Measure Availability prior to running the FHIR Queries test group.')
         fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
                        client: :data_requirements_server)
 

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../utils/data_requirements_utils'
+require 'json'
+require 'pry'
+
+module DEQMTestKit
+  # Perform fhir queries based on $data-requirements operation on test client
+  class FHIRQueries < Inferno::TestGroup
+    include DataRequirementsUtils
+    id 'fhir_queries'
+    title 'FHIR Queries'
+    description 'Ensure fhir server can handle queries resulting from $data-requirements operation'
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
+    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000',
+                        options: measure_options }
+
+    fhir_client do
+      url :url
+    end
+    # rubocop:disable Metrics/BlockLength
+    test do
+      title 'Valid FHIR Queries'
+      id 'fhir-queries-01'
+      description 'Queries resulting from a $data-requirements operation return 200 OK'
+      makes_request :fhir_queries
+      input :data_requirements_server_url
+      input :measure_id, measure_id_args
+
+      fhir_client :data_requirements_server do
+        url :data_requirements_server_url
+      end
+
+      run do
+        assert(measure_id,
+               'No measure selected. Run Measure Availability prior to running the Submit Data test group.')
+        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+                       client: :data_requirements_server)
+
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+        actual_dr = resource.dataRequirement
+        queries = get_data_requirements_queries(actual_dr)
+        # Store responses to run assertions on later to ensure all requests go through before failure
+        responses = queries.map do |q|
+          fhir_search(q[:endpoint], params: q[:params])
+          { response: response,
+            query_string: "/#{q[:endpoint]}#{q[:params].size.positive? ? '?' : ''}#{URI.encode_www_form(q[:params])}" }
+        end
+        responses.each do |r|
+          assert(r[:response][:status] == 200,
+                 "Expected response code 200, received: #{r[:response][:status]} for query: #{r[:query_string]}")
+          assert_valid_json(r[:response][:body],
+                            "Received invalid JSON body on query response for query: #{r[:query_string]}")
+        end
+      end
+    end
+    # rubocop:enable Metrics/BlockLength
+  end
+end

--- a/spec/deqm_test_kit/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/bulk_import_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::BulkImport do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[7] }
+  let(:group) { suite.groups[8] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/bulk_submit_data_spec.rb
+++ b/spec/deqm_test_kit/bulk_submit_data_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::BulkSubmitData do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[6] }
+  let(:group) { suite.groups[7] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/care_gaps_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::CareGaps do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[5] }
+  let(:group) { suite.groups[6] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -6,7 +6,7 @@ INVALID_REPORT_TYPE = 'INVALID_REPORT_TYPE'
 
 RSpec.describe DEQMTestKit::EvaluateMeasure do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[4] }
+  let(:group) { suite.groups[5] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/fhir_queries_spec.rb
+++ b/spec/deqm_test_kit/fhir_queries_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DEQMTestKit::FHIRQueries do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe 'data requirements matches embedded results test' do
+  describe 'FHIR queries with successful $data-requirements request' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:condition_id) { 'test-condition' }

--- a/spec/deqm_test_kit/fhir_queries_spec.rb
+++ b/spec/deqm_test_kit/fhir_queries_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe DEQMTestKit::FHIRQueries do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
+  let(:group) { suite.groups[3] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+  let(:test_condition_response) { FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test-condition' } }]) }
+
+  let(:test_library_response) do
+    FHIR::Library.new(dataRequirement: [{ type: 'Condition' }])
+  end
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name: name, value: value, type: 'text')
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  describe 'data requirements matches embedded results test' do
+    let(:test) { group.tests.first }
+    let(:measure_id) { 'measure-EXM130-7.3.000' }
+    let(:condition_id) { 'test-condition' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes if the FHIR queries return 200 and valid JSON' do
+      test_patient_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test-patient' } }])
+
+      stub_request(:get, "#{url}/Condition")
+        .to_return(status: 200, body: test_condition_response.to_json)
+
+      stub_request(:get, "#{url}/Patient")
+        .to_return(status: 200, body: test_patient_response.to_json)
+
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+      )
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, data_requirements_server_url: url)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails if a single FHIR query returns 500' do
+      stub_request(:get, "#{url}/Condition")
+        .to_return(status: 200, body: test_condition_response.to_json)
+
+      stub_request(:get, "#{url}/Patient")
+        .to_return(status: 500, body: error_outcome.to_json)
+
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+      )
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, data_requirements_server_url: url)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to eq('Expected response code 200, received: 500 for query: /Patient')
+    end
+  end
+end

--- a/spec/deqm_test_kit/patient_everything_spec.rb
+++ b/spec/deqm_test_kit/patient_everything_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 
 RSpec.describe DEQMTestKit::PatientEverything do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[8] }
+  let(:group) { suite.groups[9] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/submit_data_spec.rb
+++ b/spec/deqm_test_kit/submit_data_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DEQMTestKit::SubmitData do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_test_suite') }
-  let(:group) { suite.groups[3] }
+  let(:group) { suite.groups[4] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }


### PR DESCRIPTION
# Summary
Added a test suite that tests a servers capability to handle `GET` requests that result from the DataRequirements returned from a `$data-requirements` request

## New behavior
A new suite that takes a `data_requirements_server_url` as input and runs a `$data-requirements` operation on that server. Then, parses the returned `DataRequirements` and forms `GET` requests to the server under test based on the resourceTypes and filters listed in the DataRequirements. The suite ensures that these `GET` requests always receive `200OK` responses and valid JSON bodies.

## Code changes
 - Added `fhir_queries.rb` and `fhir_queries_spec.rb`
 - Bumped along the spec files indices for the suites I wanted to appear after `FHIR Queries`

# Testing guidance
 - `rspec`
 - Run `docker-compose pull`
 - Run `docker-compose up --build`
 - `POST` the EXM-130 bundle to `http://localhost:3000/4_0_1/`
 - Run the new `FHIR Queries` suite
 - Put in `http://deqm_test_server:3000/4_0_1` for both url and data_requirements_server_url
 - There's only one test in there, and it should pass!
 - Run all the test suites and make sure responses match what we're used to 
