### PR TITLE
FHIR Query Pattern Toggle 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3"
 services:
   inferno:
+    stdin_open: true
+    tty: true
     build:
       context: ./
     volumes:
@@ -9,10 +11,10 @@ services:
       - "4567:4567"
     depends_on:
       - validator_service
-  cqf_ruler:
-    image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
-    ports:
-      - "8080:8080"
+  # cqf_ruler:
+  #   image: mitrehealthdocker/cqf-ruler-preloaded:0.6.0.no-vs
+  #   ports:
+  #     - "8080:8080"
   validator_service:
     image: infernocommunity/fhir-validator-service:latest
     # Update this path to match your directory structure
@@ -40,6 +42,8 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   worker:
+    stdin_open: true
+    tty: true
     build:
       context: ./
     volumes:

--- a/lib/utils/data_requirements_utils.rb
+++ b/lib/utils/data_requirements_utils.rb
@@ -51,5 +51,22 @@ module DEQMTestKit
       end
       q
     end
+
+    def qs_to_hash(querystring)
+      querystring.split('&').inject({}) do |result, q|
+        k, v = q.split('=')
+        if !v.nil?
+          if v == 'Patient/{{context.patientId}}'
+            result
+          else
+            result.merge({ k => v })
+          end
+        elsif !result.key?(k)
+          result.merge({ k => true })
+        else
+          result
+        end
+      end
+    end
   end
 end

--- a/spec/deqm_test_kit/fhir_queries_spec.rb
+++ b/spec/deqm_test_kit/fhir_queries_spec.rb
@@ -10,7 +10,18 @@ RSpec.describe DEQMTestKit::FHIRQueries do
   let(:test_condition_response) { FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test-condition' } }]) }
 
   let(:test_library_response) do
+    FHIR::Library.new(dataRequirement: [{ type: 'Condition',
+                                          extension: [{ url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern',
+                                                        valueString: '/Condition?code:in=testvs' }, { url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern',
+                                                                                                      valueString: '/Condition?code:in=testvs2' }] }])
+  end
+
+  let(:test_library_response_no_extension) do
     FHIR::Library.new(dataRequirement: [{ type: 'Condition' }])
+  end
+
+  let(:test_patient_response) do 
+    FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test-patient' } }])
   end
 
   def run(runnable, inputs = {})
@@ -29,8 +40,7 @@ RSpec.describe DEQMTestKit::FHIRQueries do
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
 
-    it 'passes if the FHIR queries return 200 and valid JSON' do
-      test_patient_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test-patient' } }])
+    it 'passes if the FHIR queries does not use FHIR query pattern, returns 200 and valid JSON' do
 
       stub_request(:get, "#{url}/Condition")
         .to_return(status: 200, body: test_condition_response.to_json)
@@ -47,7 +57,39 @@ RSpec.describe DEQMTestKit::FHIRQueries do
       result = run(test, url: url, measure_id: measure_id, data_requirements_server_url: url)
       expect(result.result).to eq('pass')
     end
-    it 'fails if a single FHIR query returns 500' do
+    it 'passes if the FHIR queries uses FHIR query pattern, returns 200 and valid JSON' do
+      test_patient_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test-patient' } }])
+
+      stub_request(:get, "#{url}/Condition?code:in=testvs")
+        .to_return(status: 200, body: test_condition_response.to_json)
+
+      stub_request(:get, "#{url}/Condition?code:in=testvs2")
+        .to_return(status: 200, body: test_condition_response.to_json)
+
+      stub_request(:get, "#{url}/Patient")
+        .to_return(status: 200, body: test_patient_response.to_json)
+
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+      )
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, use_fqp_extension: 'true', data_requirements_server_url: url)
+      expect(result.result).to eq('pass')
+    end
+    it 'fails if use FHIR query pattern is toggled, but no fqp extension present' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+      )
+        .to_return(status: 200, body: test_library_response_no_extension.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, use_fqp_extension: 'true', data_requirements_server_url: url)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to eq('Use FHIR query pattern selected and no FHIR Query Pattern Extension found on DataRequirements')
+    end
+    it 'fails if a single FHIR query returns 500 and use FHIR query extension set to false' do
       stub_request(:get, "#{url}/Condition")
         .to_return(status: 200, body: test_condition_response.to_json)
 
@@ -63,6 +105,26 @@ RSpec.describe DEQMTestKit::FHIRQueries do
       result = run(test, url: url, measure_id: measure_id, data_requirements_server_url: url)
       expect(result.result).to eq('fail')
       expect(result.result_message).to eq('Expected response code 200, received: 500 for query: /Patient')
+    end
+    it 'fails if a single FHIR query returns 500 and use FHIR query extension set to true' do
+      stub_request(:get, "#{url}/Condition?code:in=testvs")
+        .to_return(status: 200, body: test_condition_response.to_json)
+
+      stub_request(:get, "#{url}/Condition?code:in=testvs2")
+        .to_return(status: 500, body: error_outcome.to_json)
+
+      stub_request(:get, "#{url}/Patient")
+        .to_return(status: 200, body: test_patient_response.to_json)
+
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+      )
+        .to_return(status: 200, body: test_library_response.to_json)
+
+      result = run(test, url: url, measure_id: measure_id, use_fqp_extension: 'true', data_requirements_server_url: url)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to eq('Expected response code 200, received: 500 for query: /Condition?code%3Ain=testvs2')
     end
   end
 end


### PR DESCRIPTION
# Summary
Adds a true/false toggle for option to use the FHIR query pattern extension when running the FHIR Queries suite

## New behavior
New option under FHIR Queries suite to use FHIR query pattern extension. When set to true, the suite will execute FHIR queries using the url in the extension rather than the filters on the data requirement. Currently strips off the {{context.patientId}} substring included in the extension 

## Code changes
 - Added new true/false radio in FHIR Queries suite
 - Added functionality to parse fhir query extension into params object
 - Updated FHIR Queries suite logic to pull params from fqm extension when toggle set to true
 - Added testing 
 
# Testing guidance
- Run tests with `rspec`
- Boot up inferno with `docker compose up --build`
- Select FHIR Queries suite
- Run all tests, leaving `Use FHIR Query Pattern` set to false and `http://deqm_test_server:3000/4_0_1` for both `url` and `data_requirements_server_url`. Ensure all pass
- Repeat with `Use FHIR Query Pattern` set to true.
- The test should fail due to some issues with the test server's processing of the `date` parameter, but ensure that all requests that do not use the date parameter succeed with 200
