### PR TITLE
Stop Repeating Ourselves (in assertions and requests)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
 Metrics/BlockLength:
   Enabled: true
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Metrics/PerceivedComplexity:
   Max: 10

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -6,6 +6,24 @@ module DEQMTestKit
   # tests for $care-gaps
   # rubocop:disable Metrics/ClassLength
   class CareGaps < Inferno::TestGroup
+    module CareGapsHelpers
+      def care_gaps_assert_success(params, response_status: 200)
+        fhir_operation("/Measure/$care-gaps?#{params}")
+
+        assert_response_status(response_status)
+        assert_resource_type(:parameters)
+        assert_valid_json(response[:body])
+      end
+
+      def care_gaps_assert_failure(params, response_status: 400)
+        fhir_operation("/Measure/$care-gaps?#{params}")
+
+        assert_response_status(response_status)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
     id 'care_gaps'
     title 'Gaps in Care'
     description 'Ensure FHIR server can calculate gaps in care for a measure'
@@ -22,6 +40,7 @@ module DEQMTestKit
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
 
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps proper calculation with required query parameters for Patient subject'
       id 'care-gaps-01'
       description %(Server should properly return a care gaps report
@@ -35,14 +54,11 @@ module DEQMTestKit
       run do
         params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                  "&subject=Patient/#{patient_id}&status=open-gap"
-        fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:parameters)
-        assert_valid_json(response[:body])
+        care_gaps_assert_success(params)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps proper calculation with required query parameters for Group subject'
       id 'care-gaps-02'
       description %(Server should properly return a care gaps report
@@ -56,14 +72,11 @@ module DEQMTestKit
       run do
         params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                  "&subject=Group/#{group_id}&status=open-gap"
-        fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:parameters)
-        assert_valid_json(response[:body])
+        care_gaps_assert_success(params)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps returns a BadRequest error for missing required query parameter'
       id 'care-gaps-03'
       description %(Server should not perform calculation and return a 400 response code
@@ -75,15 +88,17 @@ module DEQMTestKit
 
       run do
         invalid_params = "measureId=#{measure_id}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&status=open-gap"
-        fhir_operation("/Measure/$care-gaps?#{invalid_params}")
+        # fhir_operation("/Measure/$care-gaps?#{invalid_params}")
 
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        # assert_response_status(400)
+        # assert_valid_json(response[:body])
+        # assert(resource.resourceType == 'OperationOutcome')
+        # assert(resource.issue[0].severity == 'error')
+        care_gaps_assert_failure(invalid_params)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps returns a BadRequest error for subject and organization query parameters'
       id 'care-gaps-04'
       description %(Server should not perform calculation and return a 400 response code
@@ -99,15 +114,11 @@ module DEQMTestKit
         # A request with invalid practitioner and organization ids
         invalid_optional = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                            "&subject=Patient/#{patient_id}&status=open-gap&organization=Organization/testOrganization"
-        fhir_operation("/Measure/$care-gaps?#{invalid_optional}")
-
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        care_gaps_assert_failure(invalid_optional)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps returns a BadRequest error for invalid subject format'
       id 'care-gaps-05'
       description %(Server should not perform calculation and return a 400 response code
@@ -120,15 +131,11 @@ module DEQMTestKit
         # Parameters with an invalid patient id for subject
         invalid_subject = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                           "&status=open-gap&subject=#{INVALID_SUBJECT_ID}"
-        fhir_operation("/Measure/$care-gaps?#{invalid_subject}")
-
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        care_gaps_assert_failure(invalid_subject)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps proper calculation when no measure identifier is provided'
       id 'care-gaps-06'
       description %(Server should properly return a care gaps report
@@ -140,14 +147,11 @@ module DEQMTestKit
 
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&status=open-gap"
-        fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:parameters)
-        assert_valid_json(response[:body])
+        care_gaps_assert_success(params)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps returns NotFound error when invalid measure identifier is provided'
       id 'care-gaps-07'
       description %(Server should not perform calculation and return a 404 response code
@@ -159,15 +163,11 @@ module DEQMTestKit
       run do
         params = "measureId=#{INVALID_MEASURE_ID}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                  "&subject=Patient/#{patient_id}&status=open-gap"
-        fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(404)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        care_gaps_assert_failure(params, response_status: 404)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps proper calculation with practitioner and organization query parameters'
       id 'care-gaps-08'
       description %(Server should properly return a care gaps report
@@ -182,14 +182,11 @@ module DEQMTestKit
       run do
         params = "measureId=#{measure_id}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                  "&status=open-gap&practitioner=Practitioner/#{practitioner_id}&organization=Organization/#{org_id}"
-        fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:parameters)
-        assert_valid_json(response[:body])
+        care_gaps_assert_success(params)
       end
     end
     test do
+      include CareGapsHelpers
       title 'Check $care-gaps proper calculation with program query parameter'
       id 'care-gaps-09'
       description %(Server should properly return a care gaps report
@@ -202,11 +199,7 @@ module DEQMTestKit
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}" \
                  "&subject=Patient/#{patient_id}&status=open-gap&program=eligible-provider"
-        fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(200)
-        assert_resource_type(:parameters)
-        assert_valid_json(response[:body])
+        care_gaps_assert_success(params)
       end
     end
   end

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -88,12 +88,6 @@ module DEQMTestKit
 
       run do
         invalid_params = "measureId=#{measure_id}&periodEnd=#{period_end}&subject=Patient/#{patient_id}&status=open-gap"
-        # fhir_operation("/Measure/$care-gaps?#{invalid_params}")
-
-        # assert_response_status(400)
-        # assert_valid_json(response[:body])
-        # assert(resource.resourceType == 'OperationOutcome')
-        # assert(resource.issue[0].severity == 'error')
         care_gaps_assert_failure(invalid_params)
       end
     end

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require_relative '../utils/assertion_utils'
 
 module DEQMTestKit
   # tests for $care-gaps
@@ -8,21 +9,14 @@ module DEQMTestKit
   class CareGaps < Inferno::TestGroup
     # module for shared code for $care-gaps assertions and requests
     module CareGapsHelpers
-      def care_gaps_assert_success(params, response_status: 200)
+      def care_gaps_assert_success(params, expected_status: 200)
         fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(response_status)
-        assert_resource_type(:parameters)
-        assert_valid_json(response[:body])
+        assert_success(:parameters, expected_status)
       end
 
-      def care_gaps_assert_failure(params, response_status: 400)
+      def care_gaps_assert_failure(params, expected_status: 400)
         fhir_operation("/Measure/$care-gaps?#{params}")
-
-        assert_response_status(response_status)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_error(expected_status)
       end
     end
     id 'care_gaps'
@@ -158,7 +152,7 @@ module DEQMTestKit
       run do
         params = "measureId=#{INVALID_MEASURE_ID}&periodStart=#{period_start}&periodEnd=#{period_end}" \
                  "&subject=Patient/#{patient_id}&status=open-gap"
-        care_gaps_assert_failure(params, response_status: 404)
+        care_gaps_assert_failure(params, expected_status: 404)
       end
     end
     test do

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -6,6 +6,7 @@ module DEQMTestKit
   # tests for $care-gaps
   # rubocop:disable Metrics/ClassLength
   class CareGaps < Inferno::TestGroup
+    # module for shared code for $care-gaps assertions and requests
     module CareGapsHelpers
       def care_gaps_assert_success(params, response_status: 200)
         fhir_operation("/Measure/$care-gaps?#{params}")

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -108,10 +108,6 @@ module DEQMTestKit
         # Run our data requirements operation on the test client server
         fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)
         assert_dr_failure
-        # assert_response_status(400)
-        # assert_valid_json(response[:body])
-        # assert(resource.resourceType == 'OperationOutcome')
-        # assert(resource.issue[0].severity == 'error')
       end
     end
 
@@ -128,10 +124,6 @@ module DEQMTestKit
           body: PARAMS
         )
         assert_dr_failure(expected_status: 404)
-        # assert_response_status(404)
-        # assert_valid_json(response[:body])
-        # assert(resource.resourceType == 'OperationOutcome')
-        # assert(resource.issue[0].severity == 'error')
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -7,6 +7,7 @@ module DEQMTestKit
   # GET [base]/Measure/CMS146/$data-requirements?periodStart=2014&periodEnd=2014
   class DataRequirements < Inferno::TestGroup
     include DataRequirementsUtils
+    # module for shared code for $data-requirements assertions and requests
     module DataRequirementsHelpers
       def assert_dr_failure(expected_status: 400)
         assert_response_status(expected_status)

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -10,10 +10,7 @@ module DEQMTestKit
     # module for shared code for $data-requirements assertions and requests
     module DataRequirementsHelpers
       def assert_dr_failure(expected_status: 400)
-        assert_response_status(expected_status)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_error(expected_status)
       end
     end
     id 'data_requirements'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -6,6 +6,7 @@ module DEQMTestKit
   # tests for $evaluate-measure
   # rubocop:disable Metrics/ClassLength
   class EvaluateMeasure < Inferno::TestGroup
+    # module for shared code for $evaluate-measure assertions and requests
     module MeasureEvaluationHelpers
       def measure_evaluation_assert_success(report_type, resource_type, params, expected_status: 200)
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -8,7 +8,7 @@ module DEQMTestKit
   class EvaluateMeasure < Inferno::TestGroup
     # module for shared code for $evaluate-measure assertions and requests
     module MeasureEvaluationHelpers
-      def measure_evaluation_assert_success(report_type, resource_type, params, expected_status: 200)
+      def measure_evaluation_assert_success(_report_type, resource_type, params, expected_status: 200)
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
         assert_success(resource_type, expected_status)
       end

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -6,6 +6,17 @@ module DEQMTestKit
   # tests for $evaluate-measure
   # rubocop:disable Metrics/ClassLength
   class EvaluateMeasure < Inferno::TestGroup
+    module MeasureEvaluationTest
+      def measure_evaluation_run_block(type, expected_status: 200)
+        run do
+          fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+          assert_response_status(expected_status)
+          assert_resource_type(:measure_report)
+          assert_valid_json(response[:body])
+          assert(resource.type == type)
+        end
+      end
+    end
     id 'evaluate_measure'
     title 'Evaluate Measure'
     description 'Ensure FHIR server can calculate a measure'
@@ -22,6 +33,7 @@ module DEQMTestKit
     INVALID_REPORT_TYPE = 'INVALID_REPORT_TYPE'
 
     test do
+      extend MeasureEvaluationTest
       title 'Check $evaluate-measure proper calculation for individual report with required query parameters'
       id 'evaluate-measure-01'
       description %(Server should properly return an individual measure report when provided a
@@ -33,12 +45,14 @@ module DEQMTestKit
 
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}"
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        # fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
-        assert_response_status(200)
-        assert_resource_type(:measure_report)
-        assert_valid_json(response[:body])
-        assert(resource.type == 'individual')
+        # assert_response_status(200)
+        # assert_resource_type(:measure_report)
+        # assert_valid_json(response[:body])
+        # assert(resource.type == 'individual')
+        measure_evaluation_run_block('individual')
+
       end
     end
 
@@ -54,12 +68,14 @@ module DEQMTestKit
 
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=subject-list"
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        # fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
-        assert_response_status(200)
-        assert_resource_type(:measure_report)
-        assert_valid_json(response[:body])
-        assert(resource.type == 'subject-list')
+        # assert_response_status(200)
+        # assert_resource_type(:measure_report)
+        # assert_valid_json(response[:body])
+        # assert(resource.type == 'subject-list')
+        measure_evaluation_run_block('subject-list')
+
       end
     end
 
@@ -76,10 +92,12 @@ module DEQMTestKit
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=population"
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
-        assert_response_status(200)
-        assert_resource_type(:measure_report)
-        assert_valid_json(response[:body])
-        assert(resource.type == 'summary')
+        # assert_response_status(200)
+        # assert_resource_type(:measure_report)
+        # assert_valid_json(response[:body])
+        # assert(resource.type == 'summary')
+        measure_evaluation_run_block('summary')
+
       end
     end
     test do
@@ -94,12 +112,14 @@ module DEQMTestKit
 
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=population&subject=Group/#{group_id}"
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        # fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
 
-        assert_response_status(200)
-        assert_resource_type(:measure_report)
-        assert_valid_json(response[:body])
-        assert(resource.type == 'summary')
+        # assert_response_status(200)
+        # assert_resource_type(:measure_report)
+        # assert_valid_json(response[:body])
+        # assert(resource.type == 'summary')
+        measure_evaluation_run_block('summary')
+
       end
     end
     test do

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -10,18 +10,12 @@ module DEQMTestKit
     module MeasureEvaluationHelpers
       def measure_evaluation_assert_success(report_type, resource_type, params, expected_status: 200)
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
-        assert_response_status(expected_status)
-        assert_resource_type(resource_type)
-        assert_valid_json(response[:body])
-        assert(resource.type == report_type)
+        assert_success(resource_type, expected_status)
       end
 
       def measure_evaluation_assert_failure(params, measure_id, expected_status: 400)
         fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
-        assert_response_status(expected_status)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_error(expected_status)
       end
     end
     id 'evaluate_measure'

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -13,10 +13,7 @@ module DEQMTestKit
                'No measure selected. Run Measure Availability prior to running the FHIR Queries test group.')
         fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
                        client: :data_requirements_server)
-
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
+        assert_success(:library, 200)
         resource.dataRequirement
       end
 

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -6,6 +6,7 @@ module DEQMTestKit
   # Perform fhir queries based on $data-requirements operation on test client
   class FHIRQueries < Inferno::TestGroup
     include DataRequirementsUtils
+    # module for shared code for fhir queries assertions and requests
     module FHIRQueriesHelpers
       def dr_assertions(measure_id)
         assert(measure_id,
@@ -19,6 +20,8 @@ module DEQMTestKit
         resource.dataRequirement
       end
 
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def fhir_queries_assertions(queries)
         # Store responses to run assertions on later to ensure all requests go through before failure
         responses = queries.map do |q|
@@ -33,6 +36,8 @@ module DEQMTestKit
                             "Received invalid JSON body on query response for query: #{r[:query_string]}")
         end
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
     end
     id 'fhir_queries'
     title 'FHIR Queries'

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -4,7 +4,6 @@ require 'json'
 
 module DEQMTestKit
   # Perform fhir queries based on $data-requirements operation on test client
-  # rubocop:disable Metrics/ClassLength
   class FHIRQueries < Inferno::TestGroup
     include DataRequirementsUtils
     module FHIRQueriesHelpers
@@ -147,5 +146,4 @@ module DEQMTestKit
     end
     # rubocop:enable Metrics/BlockLength
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -7,6 +7,34 @@ module DEQMTestKit
   # rubocop:disable Metrics/ClassLength
   class FHIRQueries < Inferno::TestGroup
     include DataRequirementsUtils
+    module FHIRQueriesHelpers
+      def dr_assertions(measure_id)
+        assert(measure_id,
+               'No measure selected. Run Measure Availability prior to running the FHIR Queries test group.')
+        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+                       client: :data_requirements_server)
+
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+        resource.dataRequirement
+      end
+
+      def fhir_queries_assertions(queries)
+        # Store responses to run assertions on later to ensure all requests go through before failure
+        responses = queries.map do |q|
+          fhir_search(q[:endpoint], params: q[:params])
+          { response: response,
+            query_string: "/#{q[:endpoint]}#{q[:params].size.positive? ? '?' : ''}#{URI.encode_www_form(q[:params])}" }
+        end
+        responses.each do |r|
+          assert(r[:response][:status] == 200,
+                 "Expected response code 200, received: #{r[:response][:status]} for query: #{r[:query_string]}")
+          assert_valid_json(r[:response][:body],
+                            "Received invalid JSON body on query response for query: #{r[:query_string]}")
+        end
+      end
+    end
     id 'fhir_queries'
     title 'FHIR Queries'
     description 'Ensure FHIR server can handle queries resulting from $data-requirements operation'
@@ -32,6 +60,7 @@ module DEQMTestKit
     end
     # rubocop:disable Metrics/BlockLength
     test do
+      include FHIRQueriesHelpers
       title 'Valid FHIR Queries for All Patients'
       id 'fhir-queries-01'
       description 'Queries resulting from a $data-requirements operation return 200 OK'
@@ -45,15 +74,7 @@ module DEQMTestKit
       end
 
       run do
-        assert(measure_id,
-               'No measure selected. Run Measure Availability prior to running the FHIR Queries test group.')
-        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
-                       client: :data_requirements_server)
-
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
-        actual_dr = resource.dataRequirement
+        actual_dr = dr_assertions(measure_id)
         queries = []
         if use_fqp_extension == 'true'
           actual_dr.map do |dr|
@@ -77,24 +98,13 @@ module DEQMTestKit
         else
           queries = get_data_requirements_queries(actual_dr, include_patient: true)
         end
-
-        # Store responses to run assertions on later to ensure all requests go through before failure
-        responses = queries.map do |q|
-          fhir_search(q[:endpoint], params: q[:params])
-          { response: response,
-            query_string: "/#{q[:endpoint]}#{q[:params].size.positive? ? '?' : ''}#{URI.encode_www_form(q[:params])}" }
-        end
-        responses.each do |r|
-          assert(r[:response][:status] == 200,
-                 "Expected response code 200, received: #{r[:response][:status]} for query: #{r[:query_string]}")
-          assert_valid_json(r[:response][:body],
-                            "Received invalid JSON body on query response for query: #{r[:query_string]}")
-        end
+        fhir_queries_assertions(queries)
       end
     end
     # rubocop:enable Metrics/BlockLength
     # rubocop:disable Metrics/BlockLength
     test do
+      include FHIRQueriesHelpers
       title 'Valid FHIR Queries Single Patient'
       id 'fhir-queries-02'
       description 'Queries resulting from a $data-requirements operation return 200 OK'
@@ -109,15 +119,7 @@ module DEQMTestKit
       end
 
       run do
-        assert(measure_id,
-               'No measure selected. Run Measure Availability prior to running the FHIR Queries test group.')
-        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
-                       client: :data_requirements_server)
-
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
-        actual_dr = resource.dataRequirement
+        actual_dr = dr_assertions(measure_id)
         queries = []
 
         actual_dr.each do |dr|
@@ -140,19 +142,7 @@ module DEQMTestKit
             end
           end
         end
-
-        # Store responses to run assertions on later to ensure all requests go through before failure
-        responses = queries.map do |q|
-          fhir_search(q[:endpoint], params: q[:params])
-          { response: response,
-            query_string: "/#{q[:endpoint]}#{q[:params].size.positive? ? '?' : ''}#{URI.encode_www_form(q[:params])}" }
-        end
-        responses.each do |r|
-          assert(r[:response][:status] == 200,
-                 "Expected response code 200, received: #{r[:response][:status]} for query: #{r[:query_string]}")
-          assert_valid_json(r[:response][:body],
-                            "Received invalid JSON body on query response for query: #{r[:query_string]}")
-        end
+        fhir_queries_assertions(queries)
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -5,6 +5,7 @@ require 'json'
 module DEQMTestKit
   # MeasureAvailability test group ensures selected measures are available on the fhir server
   class MeasureAvailability < Inferno::TestGroup
+    # module for shared code for measure availability assertions and requests
     module MeasureAvailabilityHelpers
       def measure_availability_assert_success(measure_identifier, measure_version)
         # Search system for measure by identifier and version

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -10,9 +10,7 @@ module DEQMTestKit
       def measure_availability_assert_success(measure_identifier, measure_version)
         # Search system for measure by identifier and version
         fhir_search(:measure, params: { name: measure_identifier, version: measure_version })
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
+        assert_success(:bundle, 200)
       end
     end
     id 'measure_availability'

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -5,6 +5,15 @@ require 'json'
 module DEQMTestKit
   # MeasureAvailability test group ensures selected measures are available on the fhir server
   class MeasureAvailability < Inferno::TestGroup
+    module MeasureAvailabilityHelpers
+      def measure_availability_assert_success(measure_identifier, measure_version)
+        # Search system for measure by identifier and version
+        fhir_search(:measure, params: { name: measure_identifier, version: measure_version })
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+      end
+    end
     id 'measure_availability'
     title 'Measure Availability'
     description 'Ensure selected measures are available on the fhir server'
@@ -17,6 +26,7 @@ module DEQMTestKit
     measure_id_args = { type: 'radio', optional: false, default: 'EXM130|7.3.000', options: measure_options }
 
     test do
+      include MeasureAvailabilityHelpers
       title 'Measure can be found'
       id 'measure-availability-01'
       description 'Selected measure with matching id is available on the server and a valid json object'
@@ -27,18 +37,14 @@ module DEQMTestKit
         # Look for matching measure from cqf-ruler datastore by resource id
         measure_to_test = selected_measure_id
         measure_identifier, measure_version = measure_to_test.split('|')
-
-        # Search system for measure by identifier and version
-        fhir_search(:measure, params: { name: measure_identifier, version: measure_version }, name: :measure_search)
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
+        measure_availability_assert_success(measure_identifier, measure_version)
         assert resource.total.positive?,
                "Expected to find measure with identifier #{measure_identifier} and version #{measure_version}"
         output measure_id: resource.entry[0].resource.id
       end
     end
     test do
+      include MeasureAvailabilityHelpers
       title 'Measure cannot be found returns empty bundle'
       id 'measure-availability-02'
       description 'Selected measure is know not to exist on the server and returns an empty bundle'
@@ -48,12 +54,7 @@ module DEQMTestKit
       run do
         measure_identifier = 'NON-EXISTENT_MEASURE_ID'
         measure_version = '0'
-
-        # Search system for measure by identifier and version
-        fhir_search(:measure, params: { name: measure_identifier, version: measure_version })
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
+        measure_availability_assert_success(measure_identifier, measure_version)
         assert resource.total.zero?,
                "Expected to return empty bundle when passed\"
                identifier #{measure_identifier} and version #{measure_version}"

--- a/lib/deqm_test_kit/patient_everything.rb
+++ b/lib/deqm_test_kit/patient_everything.rb
@@ -10,9 +10,7 @@ module DEQMTestKit
       def patient_everything_assert_success(endpoint, body)
         fhir_operation('/', body: body)
         fhir_operation(endpoint)
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
+        assert_success(:bundle, 200)
       end
     end
     id 'patient_everything'

--- a/lib/deqm_test_kit/patient_everything.rb
+++ b/lib/deqm_test_kit/patient_everything.rb
@@ -5,6 +5,7 @@ require 'json'
 module DEQMTestKit
   # Perform Patient/$everything operation on test client
   class PatientEverything < Inferno::TestGroup
+    # module for shared code for Patient/$everything assertions and requests
     module PatientEverythingHelpers
       def patient_everything_assert_success(endpoint, body)
         fhir_operation('/', body: body)

--- a/lib/deqm_test_kit/patient_everything.rb
+++ b/lib/deqm_test_kit/patient_everything.rb
@@ -5,6 +5,15 @@ require 'json'
 module DEQMTestKit
   # Perform Patient/$everything operation on test client
   class PatientEverything < Inferno::TestGroup
+    module PatientEverythingHelpers
+      def patient_everything_assert_success(endpoint, body)
+        fhir_operation('/', body: body)
+        fhir_operation(endpoint)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+      end
+    end
     id 'patient_everything'
     title 'Patient/$everything'
     description 'Ensure FHIR server can respond to the Patient/$everything request'
@@ -16,6 +25,7 @@ module DEQMTestKit
     TEST_PATIENT_ID = 'test-patient'
 
     test do
+      include PatientEverythingHelpers
       title 'Patient/<id>/$everything valid submission'
       id 'patient-everything-01'
       description 'Patient data is received for single patient on the server'
@@ -24,12 +34,9 @@ module DEQMTestKit
         single_patient_file = File.open('./lib/fixtures/singlePatientBundle.json')
         single_patient_bundle = JSON.parse(single_patient_file.read)
         # Upload single patient bundle to server
-        fhir_operation('/', body: single_patient_bundle)
+        patient_everything_assert_success("Patient/#{TEST_PATIENT_ID}/$everything", single_patient_bundle)
         # Run Patient/<id>/$everything operation on the test client server
-        fhir_operation("Patient/#{TEST_PATIENT_ID}/$everything")
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
+
         # Check all necessary resources are included in the response
         # Note Condition resource does not include patient ref, so subtract 1
         assert(single_patient_bundle['entry'].length - 1 == resource.total,
@@ -42,6 +49,7 @@ module DEQMTestKit
     end
 
     test do
+      include PatientEverythingHelpers
       title 'Patient/$everything valid submission'
       id 'patient-everything-02'
       description 'Patient data is received for all patients on the server'
@@ -50,12 +58,7 @@ module DEQMTestKit
         multiple_patient_file = File.open('./lib/fixtures/multiplePatientBundle.json')
         multiple_patient_bundle = JSON.parse(multiple_patient_file.read)
         # Upload multiple patient bundle to server
-        fhir_operation('/', body: multiple_patient_bundle)
-        # Run Patient/$everything operation on the test client server
-        fhir_operation('Patient/$everything')
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
+        patient_everything_assert_success('Patient/$everything', multiple_patient_bundle)
         # Check all necessary resources are included in the response
         # Note all resources should be included because they all reference a patient
         # Use >=, as other data may be retrieved from server in addition to what we expect

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -6,6 +6,33 @@ require 'json'
 module DEQMTestKit
   # Perform submit data operation on test client
   class SubmitData < Inferno::TestGroup # rubocop:disable Metrics/ClassLength
+    module SubmitDataHelpers
+      def submit_data_assert_failure(params_hash, expected_status: 400)
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
+
+        assert_response_status(expected_status)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+
+      def create_measure_report(measure_url, period_start, period_end)
+        mr = {
+          'type' => 'data-collection',
+          'measure' => measure_url,
+          'period' => {
+            'start' => period_start,
+            'end' => period_end
+          },
+          'status' => 'complete'
+        }
+        resource = FHIR::MeasureReport.new(mr)
+        resource.identifier = [FHIR::Identifier.new({ value: SecureRandom.uuid })]
+        resource
+      end
+    end
     id 'submit_data'
     title 'Submit Data'
     description 'Ensure fhir server can receive data via the $submit-data operation'
@@ -20,6 +47,7 @@ module DEQMTestKit
 
     # rubocop:disable Metrics/BlockLength
     test do
+    include SubmitDataHelpers
       title 'Submit Data valid submission'
       id 'submit-data-01'
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'
@@ -115,6 +143,7 @@ module DEQMTestKit
     end
 
     test do
+      include SubmitDataHelpers
       title 'Fails if a measureReport is not submitted'
       id 'submit-data-02'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
@@ -129,18 +158,20 @@ module DEQMTestKit
             resource: test_measure
           }]
         }
-        params = FHIR::Parameters.new params_hash
+        submit_data_assert_failure(params_hash)
+        # params = FHIR::Parameters.new params_hash
 
-        fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
+        # fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
 
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        # assert_response_status(400)
+        # assert_valid_json(response[:body])
+        # assert(resource.resourceType == 'OperationOutcome')
+        # assert(resource.issue[0].severity == 'error')
       end
     end
 
     test do
+      include SubmitDataHelpers
       title 'Fails if multiple measureReports are submitted'
       id 'submit-data-03'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
@@ -165,32 +196,18 @@ module DEQMTestKit
                         resource: measure_report
                       }]
         }
-        params = FHIR::Parameters.new params_hash
+        submit_data_assert_failure(params_hash)
 
-        fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
+        # params = FHIR::Parameters.new params_hash
 
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        # fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
+
+        # assert_response_status(400)
+        # assert_valid_json(response[:body])
+        # assert(resource.resourceType == 'OperationOutcome')
+        # assert(resource.issue[0].severity == 'error')
       end
     end
     # rubocop:enable Metrics/BlockLength
-    # rubocop:disable Metrics/MethodLength
-    def create_measure_report(measure_url, period_start, period_end)
-      mr = {
-        'type' => 'data-collection',
-        'measure' => measure_url,
-        'period' => {
-          'start' => period_start,
-          'end' => period_end
-        },
-        'status' => 'complete'
-      }
-      resource = FHIR::MeasureReport.new(mr)
-      resource.identifier = [FHIR::Identifier.new({ value: SecureRandom.uuid })]
-      resource
-    end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -12,11 +12,7 @@ module DEQMTestKit
         params = FHIR::Parameters.new params_hash
 
         fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
-
-        assert_response_status(expected_status)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_error(expected_status)
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -159,14 +159,6 @@ module DEQMTestKit
           }]
         }
         submit_data_assert_failure(params_hash)
-        # params = FHIR::Parameters.new params_hash
-
-        # fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
-
-        # assert_response_status(400)
-        # assert_valid_json(response[:body])
-        # assert(resource.resourceType == 'OperationOutcome')
-        # assert(resource.issue[0].severity == 'error')
       end
     end
 
@@ -197,15 +189,6 @@ module DEQMTestKit
                       }]
         }
         submit_data_assert_failure(params_hash)
-
-        # params = FHIR::Parameters.new params_hash
-
-        # fhir_operation("Measure/#{measure_id}/$submit-data", body: params)
-
-        # assert_response_status(400)
-        # assert_valid_json(response[:body])
-        # assert(resource.resourceType == 'OperationOutcome')
-        # assert(resource.issue[0].severity == 'error')
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -6,6 +6,7 @@ require 'json'
 module DEQMTestKit
   # Perform submit data operation on test client
   class SubmitData < Inferno::TestGroup # rubocop:disable Metrics/ClassLength
+    # module for shared code for $submit-data assertions and requests
     module SubmitDataHelpers
       def submit_data_assert_failure(params_hash, expected_status: 400)
         params = FHIR::Parameters.new params_hash
@@ -18,6 +19,7 @@ module DEQMTestKit
         assert(resource.issue[0].severity == 'error')
       end
 
+      # rubocop:disable Metrics/MethodLength
       def create_measure_report(measure_url, period_start, period_end)
         mr = {
           'type' => 'data-collection',
@@ -32,6 +34,7 @@ module DEQMTestKit
         resource.identifier = [FHIR::Identifier.new({ value: SecureRandom.uuid })]
         resource
       end
+      # rubocop:enable Metrics/MethodLength
     end
     id 'submit_data'
     title 'Submit Data'

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -47,7 +47,7 @@ module DEQMTestKit
 
     # rubocop:disable Metrics/BlockLength
     test do
-    include SubmitDataHelpers
+      include SubmitDataHelpers
       title 'Submit Data valid submission'
       id 'submit-data-01'
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'

--- a/lib/utils/assertion_utils.rb
+++ b/lib/utils/assertion_utils.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Inferno
+  module DSL
+    module Assertions
+      def assert_success(resource_type, expected_status)
+        assert_response_status(expected_status)
+        assert_resource_type(resource_type)
+        assert_valid_json(response[:body])
+      end
+
+      def assert_error(expected_status)
+        assert_response_status(expected_status)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+  end
+end

--- a/lib/utils/assertion_utils.rb
+++ b/lib/utils/assertion_utils.rb
@@ -2,6 +2,7 @@
 
 module Inferno
   module DSL
+    # An extension on the existing assertions module to avoid repeptition of block assertions
     module Assertions
       def assert_success(resource_type, expected_status)
         assert_response_status(expected_status)

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
         "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
       )
         .to_return(status: 200, body: test_measure_report.to_json)
+      result = run(test, url: url, measure_id: measure_id, patient_id: patient_id, period_start: period_start,
+                         period_end: period_end)
+      expect(result.result).to eq('pass')
     end
 
     it 'fails if $evaluate-measure does not return 200' do


### PR DESCRIPTION
# Summary
Broke out repeated assertion and requests structure code into reusable blocks as suggested by Inferno team

## New behavior
None

## Code changes
Added a new helpers module to practically every test suite containing functions that make requests and assert successes or failures based on the outcome of those requests. Greatly cuts down on repeated code

# Testing guidance
We want no changed behavior here, so fire up the test kit and run things as usual to make sure everything looks correct. Also run rspec tests
