### PR TITLE
Update data requirements to not require period parameters and update …

### DIFF
--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -18,8 +18,8 @@ module DEQMTestKit
     default_url = 'https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir/$export'
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
     measure_mappings = JSON.parse(File.read('./lib/fixtures/measureCanonicalUrlMapping.json'))
-    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options,
-                        title: 'Measure ID' }
+    measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
+                        options: measure_options, title: 'Measure ID' }
 
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance"}', prefer: 'respond-async' }
 

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -28,8 +28,8 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options,
-                        title: 'Measure ID' }
+    measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
+                        options: measure_options, title: 'Measure ID' }
 
     INVALID_SUBJECT_ID = 'INVALID_SUBJECT_ID'
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -22,7 +22,8 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
+    measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
+                        options: measure_options }
 
     PARAMS = {
       resourceType: 'Parameters',
@@ -55,7 +56,7 @@ module DEQMTestKit
         measure_version = resource.version
 
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+        fhir_operation("Measure/#{measure_id}/$data-requirements",
                        body: PARAMS, name: :data_requirements)
         assert_response_status(200)
         assert_resource_type(:library)
@@ -72,7 +73,7 @@ module DEQMTestKit
 
         # Run data requirements operation on reference server
         fhir_operation(
-          "Measure/#{reference_measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+          "Measure/#{reference_measure_id}/$data-requirements",
           body: PARAMS,
           client: :dr_reference_client
         )
@@ -97,15 +98,19 @@ module DEQMTestKit
     end
 
     test do
+      optional
       include DataRequirementsHelpers
-      title 'Check data requirements returns 400 for missing parameters'
+      title 'Data requirements supports optional parameters periodStart and periodEnd'
       id 'data-requirements-02'
-      description 'Data requirements returns 400 when periodStart and periodEnd parameters are omitted'
+      description 'Data requirements returns 200 when periodStart and periodEnd parameters are included'
       input :measure_id, **measure_id_args
       run do
         # Run our data requirements operation on the test client server
-        fhir_operation("Measure/#{measure_id}/$data-requirements", body: PARAMS)
-        assert_dr_failure
+        fhir_operation("Measure/#{measure_id}/$data-requirements?periodEnd=2019-12-31&periodStart=2019-01-01",
+                       body: PARAMS)
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
       end
     end
 

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -27,7 +27,8 @@ module DEQMTestKit
     end
 
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
+    measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
+                        options: measure_options }
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -40,7 +40,7 @@ module DEQMTestKit
     title 'FHIR Queries'
     description 'Ensure FHIR server can handle queries resulting from $data-requirements operation'
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000',
+    measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
                         options: measure_options }
 
     use_fqp_extension_args = {

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -37,7 +37,8 @@ module DEQMTestKit
     description 'Ensure fhir server can receive data via the $submit-data operation'
     custom_headers = { 'X-Provenance': '{"resourceType": "Provenance", "agent": ["test-agent"]}' }
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
-    measure_id_args = { type: 'radio', optional: false, default: 'measure-EXM130-7.3.000', options: measure_options }
+    measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
+                        options: measure_options }
 
     fhir_client do
       url :url

--- a/lib/fixtures/measureAvailabilityRadioButton.json
+++ b/lib/fixtures/measureAvailabilityRadioButton.json
@@ -1,24 +1,24 @@
 {
   "list_options": [
     {
-      "label": "EXM104",
-      "value": "EXM104|8.2.000"
+      "label": "Discharged on Antithrombotic Therapy FHIR",
+      "value": "DischargedonAntithromboticTherapyFHIR|2.0.012"
     },
     {
-      "label": "EXM105",
-      "value": "EXM105|8.2.000"
+      "label": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease FHIR",
+      "value": "FHIR347|0.1.021"
     },
     {
-      "label": "EXM124",
-      "value": "EXM124|9.0.000"
+      "label": "Cervical Cancer ScreeningFHIR",
+      "value": "CervicalCancerScreeningFHIR|0.0.005"
     },
     {
-      "label": "EXM125",
-      "value": "EXM125|7.3.000"
+      "label": "Breast Cancer ScreeningFHIR",
+      "value": "BreastCancerScreeningsFHIR|0.0.002"
     },
     {
-      "label": "EXM130",
-      "value": "EXM130|7.3.000"
+      "label": "Colorectal Cancer ScreeningFHIR",
+      "value": "ColorectalCancerScreeningsFHIR|0.0.003"
     }
   ]
 }

--- a/lib/fixtures/measureCanonicalUrlMapping.json
+++ b/lib/fixtures/measureCanonicalUrlMapping.json
@@ -1,7 +1,7 @@
 {
-  "measure-EXM104-8.2.000": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM104",
-  "measure-EXM105-8.2.000": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM105",
-  "measure-EXM124-9.0.000": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM124",
-  "measure-EXM125-7.3.000": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM125",
-  "measure-EXM130-7.3.000": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+  "DischargedonAntithromboticTherapyFHIR": "http://ecqi.healthit.gov/ecqms/Measure/DischargedonAntithromboticTherapyFHIR",
+  "FHIR347": "http://ecqi.healthit.gov/ecqms/Measure/FHIR347",
+  "CervicalCancerScreeningFHIR": "http://ecqi.healthit.gov/ecqms/Measure/CervicalCancerScreeningFHIR",
+  "BreastCancerScreeningsFHIR": "http://ecqi.healthit.gov/ecqms/Measure/BreastCancerScreeningsFHIR",
+  "ColorectalCancerScreeningsFHIR": "http://ecqi.healthit.gov/ecqms/Measure/ColorectalCancerScreeningsFHIR"
 }

--- a/lib/fixtures/measureRadioButton.json
+++ b/lib/fixtures/measureRadioButton.json
@@ -1,24 +1,24 @@
 {
   "list_options": [
     {
-      "label": "EXM104",
-      "value": "measure-EXM104-8.2.000"
+      "label": "Discharged on Antithrombotic Therapy FHIR",
+      "value": "DischargedonAntithromboticTherapyFHIR"
     },
     {
-      "label": "EXM105",
-      "value": "measure-EXM105-8.2.000"
+      "label": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease FHIR",
+      "value": "FHIR347"
     },
     {
-      "label": "EXM124",
-      "value": "measure-EXM124-9.0.000"
+      "label": "Cervical Cancer ScreeningFHIR",
+      "value": "CervicalCancerScreeningFHIR"
     },
     {
-      "label": "EXM125",
-      "value": "measure-EXM125-7.3.000"
+      "label": "Breast Cancer ScreeningFHIR",
+      "value": "BreastCancerScreeningsFHIR"
     },
     {
-      "label": "EXM130",
-      "value": "measure-EXM130-7.3.000"
+      "label": "Colorectal Cancer ScreeningFHIR",
+      "value": "ColorectalCancerScreeningsFHIR"
     }
   ]
 }

--- a/spec/deqm_test_kit/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/data_requirements_spec.rb
@@ -20,13 +20,11 @@ RSpec.describe DEQMTestKit::DataRequirements do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  describe 'data requirements matches reference results test' do
+  describe '$data-requirements matches reference results test' do
     let(:test) { group.tests.first }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
-    let(:period_start) { '2019-01-01' }
-    let(:period_end) { '2019-12-31' }
 
     it 'passes if the expected Library was received' do
       test_measure_response = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: measure_id } }])
@@ -44,14 +42,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
       stub_request(
         :post,
-        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements" \
-        "?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
@@ -79,14 +76,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
       stub_request(
         :post,
-        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements" \
-        "?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
@@ -114,14 +110,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
       stub_request(
         :post,
-        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements" \
-        "?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
@@ -150,14 +145,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
       stub_request(
         :post,
-        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements" \
-        "?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_library_response.to_json)
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 201, body: test_library_response.to_json)
 
@@ -188,14 +182,13 @@ RSpec.describe DEQMTestKit::DataRequirements do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{url}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_not_library_response.to_json)
 
       stub_request(
         :post,
-        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements" \
-        "?periodEnd=#{period_end}&periodStart=#{period_start}"
+        "#{data_requirements_reference_server}/Measure/#{measure_id}/$data-requirements"
       )
         .to_return(status: 200, body: test_not_library_response.to_json)
 
@@ -208,7 +201,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
     end
   end
 
-  describe '$data-requirements with missing parameters' do
+  describe '$data-requirements with period start and period end' do
     let(:test) { group.tests[1] }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
@@ -216,43 +209,37 @@ RSpec.describe DEQMTestKit::DataRequirements do
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
 
-    it 'passes with correct OperationOutcome returned' do
+    it 'passes with 200 returned' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
       )
-        .to_return(status: 400, body: error_outcome.to_json)
+        .to_return(status: 200, body: test_library_response.to_json)
       result = run(test, url:, measure_id:)
+      puts result
       expect(result.result).to eq('pass')
     end
-    it 'fails with incorrect status code returned' do
+    it 'fails if 200 not received' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
+      )
+        .to_return(status: 201, body: test_library_response.to_json)
+      result = run(test, url:, measure_id:)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/200/)
+    end
+    it 'fails when resource returned is not of type Library' do
+      stub_request(
+        :post,
+        "#{url}/Measure/#{measure_id}/$data-requirements?periodEnd=#{period_end}&periodStart=#{period_start}"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:, measure_id:)
       expect(result.result).to eq('fail')
     end
-    it 'fails when resource returned is not of type OperationOutcome' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
-      )
-        .to_return(status: 400, body: test_library_response.to_json)
-      result = run(test, url:, measure_id:)
-      expect(result.result).to eq('fail')
-    end
-    it 'fails when severity of OperationOutcome returned is not of type error' do
-      stub_request(
-        :post,
-        "#{url}/Measure/#{measure_id}/$data-requirements"
-      )
-        .to_return(status: 400, body: incorrect_severity.to_json)
-      result = run(test, url:, measure_id:)
-      expect(result.result).to eq('fail')
-    end
   end
+
   describe '$data-requirements with invalid id' do
     let(:test) { group.tests[2] }
     let(:measure_name) { 'EXM130' }


### PR DESCRIPTION
…test data for ecqm-content-r4

# Summary
Updates the data-requirements tests to make periodStart and periodEnd not required, and updates the testing data options with measures that reflect the ids found in ecqm-content-r4 so that it aligns with expected database content for the deqm-test-server

## New behavior
The test kit will now run tests to check that the server under test can appropriately handle a `program={name}` parameter instead of a measure parameter, and `organization=Organization/{id}` w/ `practitioner=Practitioner/{id}` parameters instead of subject parameter.

## Code changes
- Added tests for program and practitioner/organization parameters for the $care-gaps operation
- Added rspec testing for new tests

# Testing guidance
(may need to `docker compose pull` and/or `bundle install` if the below don't work, depending on how up to date your system already is)
- Run rspec tests using `rspec`
- Run `docker compose up --build` or local start with `ASYNC_JOBS=false bundle exec puma`
- After the server starts up, these are the following insomnia/postman requests required to run all care-gaps tests:
`PUT` to `http://localhost:3000/4_0_1/Group/Cervical-patients`, with the following body
```
{ 
  "resourceType": "Group", 
  "id": "Cervical-patients", 
  "type": "person", 
  "actual": "true", 
  "member": [
    {
      "entity": { 
        "reference": "Patient/denom-EXM124" 
      } 
    }, 
    {
      "entity": {
        "reference": "Patient/numer-EXM124"
      }
    }
  ] 
}
```
`PUT` to `http://localhost:3000/4_0_1/Organization/1`, with the following body
```
{
"resourceType": "Organization",
"id": "1"
}
```
`PUT` to `http://localhost:3000/4_0_1/Practitioner/1`, with the following body
```
{
"resourceType": "Practitioner",
"id": "1"
}
```
`PUT` to `http://localhost:3000/4_0_1/Patient/denom-EXM124`, with the following body
```
{
	"resourceType": "Patient",
	"id": "denom-EXM124",
	"managingOrganization": {
		"reference": "Organization/1"
	},
	"generalPractitioner": {
		"reference": "Practitioner/1"
	}
	
}
```
- Navigate to [http://localhost:4567](http://localhost:4567)
- Run the care-gaps suite using the following parameters:

- All tests should pass except Bulk Data

