### PR TITLE
changed $evaluate-measure to $evaluate

### DIFF
--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -3,18 +3,18 @@
 require 'json'
 
 module DEQMTestKit
-  # tests for $evaluate-measure
+  # tests for $evaluate
   # rubocop:disable Metrics/ClassLength
   class EvaluateMeasure < Inferno::TestGroup
-    # module for shared code for $evaluate-measure assertions and requests
+    # module for shared code for $evaluate assertions and requests
     module MeasureEvaluationHelpers
       def measure_evaluation_assert_success(_report_type, resource_type, params, expected_status: 200)
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        fhir_operation("/Measure/#{measure_id}/$evaluate?#{params}")
         assert_success(resource_type, expected_status)
       end
 
       def measure_evaluation_assert_failure(params, measure_id, expected_status: 400)
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        fhir_operation("/Measure/#{measure_id}/$evaluate?#{params}")
         assert_error(expected_status)
       end
     end
@@ -36,8 +36,8 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure proper calculation for individual report with required query parameters'
-      id 'evaluate-measure-01'
+      title 'Check $evaluate proper calculation for individual report with required query parameters'
+      id 'evaluate-01'
       description %(Server should properly return an individual measure report when provided a
         Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -54,8 +54,8 @@ module DEQMTestKit
     # NOTE: this test will fail for deqm-test-server
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure proper calculation for subject-list report with required query parameters'
-      id 'evaluate-measure-02'
+      title 'Check $evaluate proper calculation for subject-list report with required query parameters'
+      id 'evaluate-02'
       description %(Server should properly return subject-list measure report when provided a
       Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -70,8 +70,8 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure proper calculation for population report with required query parameters'
-      id 'evaluate-measure-03'
+      title 'Check $evaluate proper calculation for population report with required query parameters'
+      id 'evaluate-03'
       description %(Server should properly return population measure report when provided a
       Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -80,14 +80,14 @@ module DEQMTestKit
 
       run do
         params = "periodStart=#{period_start}&periodEnd=#{period_end}&reportType=population"
-        fhir_operation("/Measure/#{measure_id}/$evaluate-measure?#{params}")
+        fhir_operation("/Measure/#{measure_id}/$evaluate?#{params}")
         measure_evaluation_assert_success('summary', :measure_report, params)
       end
     end
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure proper calculation for population report with Group subject'
-      id 'evaluate-measure-04'
+      title 'Check $evaluate proper calculation for population report with Group subject'
+      id 'evaluate-04'
       description %(Server should properly return population measure report when provided a
       Group ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -102,8 +102,8 @@ module DEQMTestKit
     end
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure fails for invalid measure ID'
-      id 'evaluate-measure-05'
+      title 'Check $evaluate fails for invalid measure ID'
+      id 'evaluate-05'
       description 'Request returns a 404 error when the given measure ID cannot be found.'
       input :patient_id, title: 'Patient ID'
       input :period_start, title: 'Measurement period start', default: '2019-01-01'
@@ -117,8 +117,8 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure fails for invalid patient ID'
-      id 'evaluate-measure-06'
+      title 'Check $evaluate fails for invalid patient ID'
+      id 'evaluate-06'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2019-01-01'
@@ -132,8 +132,8 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure fails for missing required query parameter'
-      id 'evaluate-measure-07'
+      title 'Check $evaluate fails for missing required query parameter'
+      id 'evaluate-07'
       description %(Server should not perform calculation and return a 400 response code
     when one of the required query parameters is omitted from the request. In this test,
       the measurement period start is omitted from the request.)
@@ -149,8 +149,8 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure fails for missing subject query parameter (subject report type)'
-      id 'evaluate-measure-08'
+      title 'Check $evaluate fails for missing subject query parameter (subject report type)'
+      id 'evaluate-08'
       description %(Server should not perform calculation and return a 400 response code
     when the subject report type is specified but no subject has been specified in the
       query parameters.)
@@ -166,8 +166,8 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check $evaluate-measure fails for invalid reportType'
-      id 'evaluate-measure-09'
+      title 'Check $evaluate fails for invalid reportType'
+      id 'evaluate-09'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'

--- a/spec/deqm_test_kit/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/evaluate_measure_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  describe '$evaluate-measure successful individual report test' do
+  describe '$evaluate successful individual report test' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
@@ -34,7 +34,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
                                                                           measure: measure_id } }], type: 'individual')
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: test_measure_report.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_start:,
@@ -42,10 +42,10 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result).to eq('pass')
     end
 
-    it 'fails if $evaluate-measure does not return 200' do
+    it 'fails if $evaluate does not return 200' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_start:,
@@ -54,11 +54,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result_message).to match(/200/)
     end
 
-    it 'fails if $evaluate-measure does not return MeasureReport' do
+    it 'fails if $evaluate does not return MeasureReport' do
       test_library = FHIR::Library.new
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: test_library.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_start:,
@@ -68,7 +68,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure successful subject-list report test' do
+  describe '$evaluate successful subject-list report test' do
     let(:test) { group.tests[1] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
@@ -83,7 +83,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: test_measure_report.to_json)
 
@@ -91,10 +91,10 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result).to eq('pass')
     end
 
-    it 'fails if $evaluate-measure does not return 200' do
+    it 'fails if $evaluate does not return 200' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, period_start:,
@@ -103,11 +103,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result_message).to match(/200/)
     end
 
-    it 'fails if $evaluate-measure does not return MeasureReport' do
+    it 'fails if $evaluate does not return MeasureReport' do
       test_library = FHIR::Library.new
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: test_library.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:)
@@ -116,7 +116,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure successful population report test' do
+  describe '$evaluate successful population report test' do
     let(:test) { group.tests[2] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
@@ -128,7 +128,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
                                                                           measure: measure_id } }], type: 'summary')
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: test_measure_report.to_json)
 
@@ -136,10 +136,10 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result).to eq('pass')
     end
 
-    it 'fails if $evaluate-measure does not return 200' do
+    it 'fails if $evaluate does not return 200' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, period_start:,
@@ -148,11 +148,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result_message).to match(/200/)
     end
 
-    it 'fails if $evaluate-measure does not return MeasureReport' do
+    it 'fails if $evaluate does not return MeasureReport' do
       test_library = FHIR::Library.new
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: test_library.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:)
@@ -161,7 +161,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure successful population report with Group subject test' do
+  describe '$evaluate successful population report with Group subject test' do
     let(:test) { group.tests[3] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
@@ -176,7 +176,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
                                                                           measure: measure_id } }], type: 'summary')
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: test_measure_report.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:,
@@ -184,12 +184,12 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result).to eq('pass')
     end
 
-    it 'fails if $evaluate-measure does not return 200' do
+    it 'fails if $evaluate does not return 200' do
       test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
                                                                           measure: measure_id } }], type: 'summary')
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: test_measure_report.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:,
@@ -198,11 +198,11 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result_message).to match(/200/)
     end
 
-    it 'fails if $evaluate-measure does not return MeasureReport' do
+    it 'fails if $evaluate does not return MeasureReport' do
       test_library = FHIR::Library.new
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: test_library.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:,
@@ -211,7 +211,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result_message).to match(/200/)
     end
 
-    it 'fails if $evaluate-measure does not return MeasureReport of type summary' do
+    it 'fails if $evaluate does not return MeasureReport of type summary' do
       # rubocop:disable Layout/LineLength
 
       test_measure_report = FHIR::MeasureReport.new(entry: [{ resource: { resourceType: 'MeasureReport',
@@ -219,7 +219,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       # rubocop:enable Layout/LineLength
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: test_measure_report.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:,
@@ -228,7 +228,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
       expect(result.result_message).to match(/200/)
     end
   end
-  describe '$evaluate-measure fails for invalid measure id' do
+  describe '$evaluate fails for invalid measure id' do
     let(:test) { group.tests[4] }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -238,7 +238,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'passes with correct Operation-Outcome returned' do
       stub_request(
         :post,
-        "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate?#{params}"
       )
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url:, patient_id:, period_start:, period_end:)
@@ -248,7 +248,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'fails if server does not return 404 for invalid measure id' do
       stub_request(
         :post,
-        "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{INVALID_MEASURE_ID}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:, patient_id:, period_start:, period_end:)
@@ -257,7 +257,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure fails for invalid patient id' do
+  describe '$evaluate fails for invalid patient id' do
     let(:test) { group.tests[5] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
@@ -267,7 +267,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'passes with correct Operation-Outcome returned' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:)
@@ -277,7 +277,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'fails if server does not return 404 for invalid patient id' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:)
@@ -286,7 +286,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure fails for missing required params' do
+  describe '$evaluate fails for missing required params' do
     let(:test) { group.tests[6] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
@@ -296,7 +296,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'passes with correct Operation-Outcome returned' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_end:)
@@ -306,7 +306,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'fails if server does not return 400 for missing param' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_end:)
@@ -315,7 +315,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure fails for missing subject param for individual report type' do
+  describe '$evaluate fails for missing subject param for individual report type' do
     let(:test) { group.tests[7] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
@@ -325,7 +325,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'passes with correct Operation-Outcome returned' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}&reportType=subject"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}&reportType=subject"
       )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:)
@@ -335,7 +335,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'fails if server does not return 400 for missing subject param' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}&reportType=subject"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}&reportType=subject"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, period_start:, period_end:)
@@ -344,7 +344,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
 
-  describe '$evaluate-measure fails for invalid reportType' do
+  describe '$evaluate fails for invalid reportType' do
     let(:test) { group.tests[8] }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
@@ -358,7 +358,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'passes with correct Operation-Outcome returned' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_start:,
@@ -369,7 +369,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     it 'fails if server does not return 400 for invalid reportType' do
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$evaluate-measure?#{params}"
+        "#{url}/Measure/#{measure_id}/$evaluate?#{params}"
       )
         .to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:, measure_id:, patient_id:, period_start:,


### PR DESCRIPTION
# Summary
`$evaluate-measure` was renamed to `$evaluate`. Updated the name of the endpoint in all instances of the `deqm-test-kit`.

works with the [deqm-test-server](https://github.com/projecttacoma/deqm-test-server) changes 

## New behavior
No changes in behavior, test kit should function as normal.

## Code changes
Naming changes in:
- `/evaluate_measure.rb`
- `/evaluate_measure_spec.rb`

# Testing guidance
1. To test youll need to have the `deqm-test-server` running:
In the `deqm-test-server` dir:
`npm run check`
`npm run start`
Check to make sure youre on the `update-evaluate-measure` branch if it has not already been merged in.

2. Start up the test kit (Recommended to run locally):
`bundle install`
`bundle exec inferno migrate`
`ASYNC_JOBS=false bundle exec puma`
Navigate to [http://localhost:4567/](http://localhost:4567/) to run the tests in the Inferno web page.

3. Select the `local` server in the drop down and hit `RUN ALL TESTS`
4. Nothing will happen right away, so take a deep breath 😮‍💨 and count to ~33 
5. and voila! All test should pass ...except:
- 6.02
- 6.04
- 7.02
- 7.06
- 7.08
- 8.01



