### PR TITLE
Multi Measure Input

### DIFF
--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -67,7 +67,7 @@ module DEQMTestKit
     measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
                         options: measure_options, title: 'Measure Title' }
     additional_measures_args = { type: 'checkbox', optional: true,
-                                 options: measure_options, title: 'Additional Measure Ids' }
+                                 options: measure_options, title: 'Additional Measure Ids', default: [''] }
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -66,6 +66,8 @@ module DEQMTestKit
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
     measure_id_args = { type: 'radio', optional: false, default: 'ColorectalCancerScreeningsFHIR',
                         options: measure_options, title: 'Measure Title' }
+    additional_measures_args = { type: 'checkbox', optional: true,
+                                 options: measure_options, title: 'Additional Measure Ids' }
 
     INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
     INVALID_PATIENT_ID = 'INVALID_PATIENT_ID'
@@ -100,8 +102,43 @@ module DEQMTestKit
 
     test do
       include MeasureEvaluationHelpers
-      title 'Check proper calculation for individual report with required query parameters'
+      title 'Check operation output with multiple measures using Measure/$evaluate'
       id 'evaluate-02'
+      description %(Server should properly return a Parameters resource containing multiple Bundles,
+        each with measure reports for different measures when provided multiple measure IDs
+        using the Measure/$evaluate endpoint.)
+      input :measure_id, **measure_id_args
+      input :additional_measures, **additional_measures_args
+      input :patient_id, title: 'Patient ID'
+      input :period_start, title: 'Measurement period start', default: '2019-01-01'
+      input :period_end, title: 'Measurement period end', default: '2019-12-31'
+
+      run do
+        measure_ids = [measure_id]
+        measure_ids += additional_measures if additional_measures&.any?
+
+        measure_params = measure_ids.map { |id| "measureId=#{id}" }.join('&')
+        params = "#{measure_params}&periodStart=#{period_start}&periodEnd=#{period_end}&subject=Patient/#{patient_id}"
+
+        fhir_operation("/Measure/$evaluate?#{params}")
+        assert_response_status(200)
+
+        assert resource.is_a?(FHIR::Parameters),
+               "Expected resource to be a Parameters resource, but got #{resource&.class}"
+
+        validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each measure
+        expected_bundle_count = measure_ids.length
+        assert resource.parameter[0].resource.entry.length >= expected_bundle_count,
+               "Expected at #{expected_bundle_count} bundles, got #{resource.parameter[0].resource.entry.length}"
+      end
+    end
+
+    test do
+      include MeasureEvaluationHelpers
+      title 'Check proper calculation for individual report with required query parameters'
+      id 'evaluate-03'
       description %(Server should properly return a Parameters resource containing Bundles with individual
         measure reports when provided a Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -118,7 +155,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for subject-list report with required query parameters'
-      id 'evaluate-03'
+      id 'evaluate-04'
       description %(Server should properly return a Parameters resource containing Bundles with subject-list
         measure reports when provided a Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -134,7 +171,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for population report with required query parameters'
-      id 'evaluate-04'
+      id 'evaluate-05'
       description %(Server should properly return a Parameters resource containing Bundles with population
         measure reports when provided required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -150,7 +187,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for population report with Group subject'
-      id 'evaluate-05'
+      id 'evaluate-06'
       description %(Server should properly return a Parameters resource containing Bundles with population
         measure reports when provided a Group ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -167,7 +204,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid measure ID'
-      id 'evaluate-06'
+      id 'evaluate-07'
       description 'Request returns a 404 error when the given measure ID cannot be found.'
       input :patient_id, title: 'Patient ID'
       input :period_start, title: 'Measurement period start', default: '2019-01-01'
@@ -182,7 +219,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid patient ID'
-      id 'evaluate-07'
+      id 'evaluate-08'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2019-01-01'
@@ -197,7 +234,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for missing required query parameter'
-      id 'evaluate-08'
+      id 'evaluate-09'
       description %(Server should not perform calculation and return a 400 response code
     when one of the required query parameters is omitted from the request. In this test,
       the measurement period start is omitted from the request.)
@@ -214,7 +251,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for missing subject query parameter (subject report type)'
-      id 'evaluate-09'
+      id 'evaluate-10'
       description %(Server should not perform calculation and return a 400 response code
     when the subject report type is specified but no subject has been specified in the
       query parameters.)
@@ -231,7 +268,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid reportType'
-      id 'evaluate-10'
+      id 'evaluate-11'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'
@@ -248,7 +285,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid parameter structure in input'
-      id 'evaluate-11'
+      id 'evaluate-12'
       description %(Server should return 400 when the request contains malformed parameters, such as missing '=' or
       invalid query format.)
       input :measure_id, **measure_id_args
@@ -262,7 +299,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for missing periodEnd parameter in input'
-      id 'evaluate-12'
+      id 'evaluate-13'
       description %(Server should return 400 when input is missing periodEnd parameter.)
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'


### PR DESCRIPTION
# Summary
Allows for multiple measure Id's to be selected for `$evaluate` tests. 

## New behavior
<img width="623" height="886" alt="Screenshot 2025-07-10 at 10 50 26 PM" src="https://github.com/user-attachments/assets/890ffed4-ce4f-4850-b4c0-976e52f06fd9" />


## Code changes
- modified `evaluate.rb` to allow for multiple measure id's to be passed in. New checkboxes for user to select additional measure Id's to be sent in. 
- added `evaluate-02` test to check if the server returns the correct number of bundles when given multiple measure Id's (note that this test was moved up so all the other tests have a new number) 
- updated spec test for the new `evaluate-02` test. renumbered the other tests to correspond to the evaluate.rb ordering. 

 
# Testing guidance
###  With Docker:
In `deqm-test-kit`:
`./setup`
`docker compose pull`
`docker compose up --build`

### Locally:
In `deqm-test-server`:
`npm run db:reset`
`npm run upload-bundles`
`npm start`

In `deqm-test-kit`:
`bundle install`
`ASYNC_JOBS=false bundle exec puma`
Navigate to [http://localhost:4567](http://localhost:4567) for the test kit.

Testing in the `v5.0.0` for `$evaluate` select one measure and run the test, and then select multiple and run to see if the test passes. 


