### PR TITLE
Update Test Ids

### DIFF
--- a/lib/deqm_test_kit/bulk_import.rb
+++ b/lib/deqm_test_kit/bulk_import.rb
@@ -19,7 +19,7 @@ module DEQMTestKit
     # rubocop:disable Metrics/BlockLength
     test do
       title 'Ensure FHIR server can accept bulk data import requests'
-      id 'bulk-import-01'
+      id 'bulk-import-accepts-import-requests'
       description %(POST request to $import returns 202 response,
       GET request to bulk status endpoint returns 200 response)
 

--- a/lib/deqm_test_kit/bulk_submit_data.rb
+++ b/lib/deqm_test_kit/bulk_submit_data.rb
@@ -30,7 +30,7 @@ module DEQMTestKit
     # rubocop:disable Metrics/BlockLength
     test do
       title 'Ensure FHIR server can accept bulk data import requests for given measure'
-      id 'bulk-submit-data-01'
+      id 'bulk-submit-data-accepts-requests-for-measure'
       description %(POST request to $bulk-submit-data returns 202 response,
       GET request to bulk status endpoint returns 200 response)
 

--- a/lib/deqm_test_kit/care_gaps.rb
+++ b/lib/deqm_test_kit/care_gaps.rb
@@ -38,7 +38,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps proper calculation with required query parameters for Patient subject'
-      id 'care-gaps-01'
+      id 'care-gaps-patient-subject-with-required-params'
       description %(Server should properly return a care gaps report
     when the required query parameters \(periodStart, periodEnd, status\) are provided
       and subject is a Patient resource.)
@@ -56,7 +56,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps proper calculation with required query parameters for Group subject'
-      id 'care-gaps-02'
+      id 'care-gaps-group-subject-with-required-params'
       description %(Server should properly return a care gaps report
     when the required query parameters \(periodStart, periodEnd, status\) are provided
       and subject is a Group resource.)
@@ -74,7 +74,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps returns a BadRequest error for missing required query parameter'
-      id 'care-gaps-03'
+      id 'care-gaps-missing-required-parameter'
       description %(Server should not perform calculation and return a 400 response code
     when one of the required query parameters is omitted from the request. In this test,
       the measurement period start is omitted from the request.)
@@ -90,7 +90,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps returns a BadRequest error for subject and organization query parameters'
-      id 'care-gaps-04'
+      id 'care-gaps-subject-and-organization-conflict'
       description %(Server should not perform calculation and return a 400 response code
     when both the subject and organization query parameters are provided in the request.
       As stated in the $care-gaps FHIR spec, these query parameters are mutually
@@ -110,7 +110,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps returns a BadRequest error for invalid subject format'
-      id 'care-gaps-05'
+      id 'care-gaps-invalid-subject-format'
       description "Server should not perform calculation and return a 400 response code
     when both the subject query parameter is not of the form Patient/<id> or Group/<id>."
       input :measure_id, **measure_id_args
@@ -127,7 +127,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps proper calculation when no measure identifier is provided'
-      id 'care-gaps-06'
+      id 'care-gaps-no-measure-identifier-provided'
       description %(Server should properly return a care gaps report
     when the required query parameters \(periodStart, periodEnd, status\) are provided,
       subject is a Patient resource, and no measure identifier has been provided.)
@@ -143,7 +143,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps returns NotFound error when invalid measure identifier is provided'
-      id 'care-gaps-07'
+      id 'care-gaps-invalid-measure-identifier'
       description %(Server should not perform calculation and return a 404 response code
     when the provided measure identifier cannot be found on the server)
       input :patient_id, title: 'Patient ID'
@@ -159,7 +159,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps proper calculation with practitioner and organization query parameters'
-      id 'care-gaps-08'
+      id 'care-gaps-practitioner-and-organization-params'
       description %(Server should properly return a care gaps report
     when the required query parameters \(periodStart, periodEnd, status\) are provided and
       an organization and practitioner are provided rather than a Patient/Group subject.)
@@ -178,7 +178,7 @@ module DEQMTestKit
     test do
       include CareGapsHelpers
       title 'Check $care-gaps proper calculation with program query parameter'
-      id 'care-gaps-09'
+      id 'care-gaps-with-program-parameter'
       description %(Server should properly return a care gaps report
     when the required query parameters \(periodStart, periodEnd, status\) are provided and
       a program query parameter is provided.)

--- a/lib/deqm_test_kit/data_requirements.rb
+++ b/lib/deqm_test_kit/data_requirements.rb
@@ -38,7 +38,7 @@ module DEQMTestKit
     # rubocop:disable Metrics/BlockLength
     test do
       title 'Check data requirements against expected return'
-      id 'data-requirements-01'
+      id 'data-requirements-match-reference-server'
       description 'Data requirements on the FHIR test server match the data requirements of reference server'
       makes_request :data_requirements
       output :queries_json
@@ -105,7 +105,7 @@ module DEQMTestKit
       optional
       include DataRequirementsHelpers
       title 'Data requirements supports optional parameters periodStart and periodEnd'
-      id 'data-requirements-02'
+      id 'data-requirements-with-period-parameters'
       description 'Data requirements returns 200 when periodStart and periodEnd parameters are included'
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2019-01-01', optional: true
@@ -123,7 +123,7 @@ module DEQMTestKit
     test do
       include DataRequirementsHelpers
       title 'Check data requirements returns 404 for invalid measure id'
-      id 'data-requirements-03'
+      id 'data-requirements-invalid-measure-returns-404'
       description 'Data requirements returns 404 when passed a measure id which is not in the system'
 
       run do

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -68,7 +68,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate (default reportType=population)'
-      id 'evaluate-01'
+      id 'evaluate-measureid-query-default-reporttype'
       description %(Measure/[id]/$evaluate without reportType (defaults to reportType=population)
       returns 200 and FHIR Parameters resource.)
 
@@ -103,7 +103,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with measureId in Parameters resource request body without reportType (defaults to reportType=population)' # rubocop:disable Layout/LineLength
-      id 'evaluate-02'
+      id 'evaluate-measureid-body-default-reporttype'
       description %(Measure/$evaluate with measureId in Parameters resource request body and
       without reportType (defaults to reportType=population) returns 200 and FHIR Parameters resource.)
 
@@ -142,7 +142,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with reportType=subject and measureId in Parameters resource request body'
-      id 'evaluate-03'
+      id 'evaluate-subject-reporttype-body'
       description %(Measure/$evaluate with reportType=subject and subject and measureId in Parameters resource request
       body returns 200 and FHIR Parameters resource.)
 
@@ -186,7 +186,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with multiple measureIds in Parameters resource request body without reportType (defaults to reportType=population)' # rubocop:disable Layout/LineLength
-      id 'evaluate-04'
+      id 'evaluate-multiple-measureids-no-reporttype'
       description %(Measure/$evaluate without reportType (defaults to reportType=population) and subject and multiple
       measureIds in Parameters resource request body returns 200 and FHIR Parameters resource.)
       input :measure_id, **measure_id_args
@@ -232,7 +232,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with reportType=subject and multiple measureIds in Parameters resource request body'
-      id 'evaluate-05'
+      id 'evaluate-multiple-measureids-with-subject'
       description %(Measure/$evaluate with reportType=subject and subject and multiple measureIds in Parameters
       resource request body returns 200 and FHIR Parameters resource.)
       input :measure_id, **measure_id_args
@@ -280,7 +280,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with reportType=subject and subjectGroup'
-      id 'evaluate-06'
+      id 'evaluate-subjectgroup-embedded-resource'
       description %(Measure/$evaluate with reportType=subject and subjectGroup.)
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
@@ -338,7 +338,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with reportType=subject and subject Group reference'
-      id 'evaluate-07'
+      id 'evaluate-subjectgroup-reference'
       description %(Measure/$evaluate with reportType=subject and subject Group reference.)
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
@@ -385,7 +385,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate reportType=subject fails for invalid measure ID'
-      id 'evaluate-8'
+      id 'evaluate-invalid-measureid-subject'
       description 'Request returns a 404 error when the given measure ID cannot be found.'
       input :patient_id, title: 'Patient ID'
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
@@ -421,7 +421,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate fails for invalid measure ID'
-      id 'evaluate-9'
+      id 'evaluate-measureid-query-invalid-measureid'
       description 'Request returns a 404 error when the given measure ID cannot be found.'
       input :patient_id, title: 'Patient ID'
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
@@ -436,7 +436,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate reportType=subject fails for invalid patient ID'
-      id 'evaluate-10'
+      id 'evaluate-invalid-patientid-subject-body'
       description 'Request returns a 404 error when the given patient ID cannot be found.'
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
@@ -472,7 +472,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate reportType=subject fails for invalid patient ID'
-      id 'evaluate-11'
+      id 'evaluate-measureid-query-invalid-patientid'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
@@ -487,7 +487,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate fails for missing subject query parameter (subject report type)'
-      id 'evaluate-12'
+      id 'evaluate-missing-subject-param'
       description %(Server should not perform calculation and return a 400 response code
       when the subject report type is specified but no subject has been specified in the
       query parameters.)
@@ -504,7 +504,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate reportType=subject fails for invalid reportType'
-      id 'evaluate-13'
+      id 'evaluate-measureid-query-invalid-reporttype'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'
@@ -521,7 +521,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate reportType=subject fails for invalid reportType'
-      id 'evaluate-14'
+      id 'evaluate-body-invalid-reporttype'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'
@@ -562,7 +562,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate reportType=subject fails for missing periodEnd parameter in input'
-      id 'evaluate-15'
+      id 'evaluate-measureid-query-missing-periodend'
       description %(Server should return 400 when input is missing periodEnd parameter.)
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'
@@ -576,8 +576,8 @@ module DEQMTestKit
 
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
-      title 'Measure/$evaluate reportType=subject fails for missing periodEnd parameter'
-      id 'evaluate-16'
+      title 'Measure/$evaluate reportType=subject fails for missing periodEnd parameter in the body'
+      id 'evaluate-body-missing-periodend'
       description %(Server should return 400 when input is missing periodEnd parameter.)
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'

--- a/lib/deqm_test_kit/evaluate_measure.rb
+++ b/lib/deqm_test_kit/evaluate_measure.rb
@@ -41,7 +41,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for individual report with required query parameters'
-      id 'evaluate-measure-01'
+      id 'evaluate-measure-individual-with-patient-subject'
       description %(Server should properly return an individual measure report when provided a
         Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -58,7 +58,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for subject-list report with required query parameters'
-      id 'evaluate-measure-02'
+      id 'evaluate-measure-subject-list-reporttype'
       description %(Server should properly return subject-list measure report when provided a
       Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -74,7 +74,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for population report with required query parameters'
-      id 'evaluate-measure-03'
+      id 'evaluate-measure-population-reporttype'
       description %(Server should properly return population measure report when provided a
       Patient ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -90,7 +90,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check proper calculation for population report with Group subject'
-      id 'evaluate-measure-04'
+      id 'evaluate-measure-population-with-group-subject'
       description %(Server should properly return population measure report when provided a
       Group ID and required query parameters \(period start, period end\).)
       input :measure_id, **measure_id_args
@@ -107,7 +107,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid measure ID'
-      id 'evaluate-measure-05'
+      id 'evaluate-measure-invalid-measureid'
       description 'Request returns a 404 error when the given measure ID cannot be found.'
       input :patient_id, title: 'Patient ID'
       input :period_start, title: 'Measurement period start', default: '2019-01-01'
@@ -122,7 +122,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid patient ID'
-      id 'evaluate-measure-06'
+      id 'evaluate-measure-invalid-patientid'
       description 'Request returns a 404 error when the given patient ID cannot be found'
       input :measure_id, **measure_id_args
       input :period_start, title: 'Measurement period start', default: '2019-01-01'
@@ -137,7 +137,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for missing required query parameter'
-      id 'evaluate-measure-07'
+      id 'evaluate-measure-missing-period-start'
       description %(Server should not perform calculation and return a 400 response code
     when one of the required query parameters is omitted from the request. In this test,
       the measurement period start is omitted from the request.)
@@ -154,7 +154,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for missing subject query parameter (subject report type)'
-      id 'evaluate-measure-08'
+      id 'evaluate-measure-missing-subject-param'
       description %(Server should not perform calculation and return a 400 response code
     when the subject report type is specified but no subject has been specified in the
       query parameters.)
@@ -171,7 +171,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid reportType'
-      id 'evaluate-measure-09'
+      id 'evaluate-measure-invalid-reporttype'
       description 'Request returns 400 for invalid report type (not individual, population, or subject-list)'
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'
@@ -188,7 +188,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for invalid parameter structure in input'
-      id 'evaluate-measure-10'
+      id 'evaluate-measure-malformed-parameters'
       description %(Server should return 400 when the request contains malformed parameters, such as missing '=' or
       invalid query format.)
       input :measure_id, **measure_id_args
@@ -202,7 +202,7 @@ module DEQMTestKit
     test do
       include MeasureEvaluationHelpers
       title 'Check operation fails for missing periodEnd parameter in input'
-      id 'evaluate-measure-11'
+      id 'evaluate-measure-missing-periodend'
       description %(Server should return 400 when input is missing periodEnd parameter.)
       input :measure_id, **measure_id_args
       input :patient_id, title: 'Patient ID'

--- a/lib/deqm_test_kit/fhir_queries.rb
+++ b/lib/deqm_test_kit/fhir_queries.rb
@@ -81,7 +81,7 @@ module DEQMTestKit
     test do
       include FHIRQueriesHelpers
       title 'Valid FHIR Queries for All Patients'
-      id 'fhir-queries-01'
+      id 'fhir-queries-all-patients-from-data-requirements'
       description 'Queries resulting from a $data-requirements operation return 200 OK'
       makes_request :fhir_queries
       input :data_requirements_server_url
@@ -132,7 +132,7 @@ module DEQMTestKit
     test do
       include FHIRQueriesHelpers
       title 'Valid FHIR Queries Single Patient'
-      id 'fhir-queries-02'
+      id 'fhir-queries-single-patient-from-data-requirements'
       description 'Queries resulting from a $data-requirements operation return 200 OK'
       makes_request :fhir_queries
       input :data_requirements_server_url

--- a/lib/deqm_test_kit/measure_availability.rb
+++ b/lib/deqm_test_kit/measure_availability.rb
@@ -34,7 +34,7 @@ module DEQMTestKit
     test do
       include MeasureAvailabilityHelpers
       title 'Measure can be found'
-      id 'measure-availability-01'
+      id 'measure-availability-found'
       description 'Selected measure with matching id is available on the server and a valid json object'
       makes_request :measure_search
       input :selected_measure_id, **measure_id_args
@@ -54,7 +54,7 @@ module DEQMTestKit
     test do
       include MeasureAvailabilityHelpers
       title 'Measure cannot be found returns empty bundle'
-      id 'measure-availability-02'
+      id 'measure-availability-not-found'
       description 'Selected measure is know not to exist on the server and returns an empty bundle'
       makes_request :measure_search_failure
       output :null

--- a/lib/deqm_test_kit/patient_everything.rb
+++ b/lib/deqm_test_kit/patient_everything.rb
@@ -29,7 +29,7 @@ module DEQMTestKit
     test do
       include PatientEverythingHelpers
       title 'Patient/<id>/$everything valid submission'
-      id 'patient-everything-01'
+      id 'patient-everything-single-patient'
       description 'Patient data is received for single patient on the server'
 
       run do
@@ -53,7 +53,7 @@ module DEQMTestKit
     test do
       include PatientEverythingHelpers
       title 'Patient/$everything valid submission'
-      id 'patient-everything-02'
+      id 'patient-everything-all-patients'
       description 'Patient data is received for all patients on the server'
 
       run do
@@ -75,7 +75,7 @@ module DEQMTestKit
 
     test do
       title 'Patient/<id>/$everything patient ID not found'
-      id 'patient-everything-03'
+      id 'patient-everything-invalid-patient-id'
       description 'Request returns a 404 error if requested patient ID is not found'
 
       run do

--- a/lib/deqm_test_kit/submit_data.rb
+++ b/lib/deqm_test_kit/submit_data.rb
@@ -49,7 +49,7 @@ module DEQMTestKit
     test do
       include SubmitDataHelpers
       title 'Submit Data valid submission'
-      id 'submit-data-01'
+      id 'submit-data-valid-submission-with-verification'
       description 'Submit resources relevant to a measure, and then verify they persist on the server.'
       makes_request :submit_data
       input :queries_json
@@ -145,7 +145,7 @@ module DEQMTestKit
     test do
       include SubmitDataHelpers
       title 'Fails if a measureReport is not submitted'
-      id 'submit-data-02'
+      id 'submit-data-fails-missing-measurereport'
       description 'Request returns a 400 error if MeasureReport is not submitted.'
       input :measure_id, **measure_id_args
       run do
@@ -165,7 +165,7 @@ module DEQMTestKit
     test do
       include SubmitDataHelpers
       title 'Fails if multiple measureReports are submitted'
-      id 'submit-data-03'
+      id 'submit-data-fails-multiple-measurereports'
       description 'Request returns a 400 error multiple MeasureReports are not submitted.'
       input :measure_id, **measure_id_args
       run do

--- a/spec/deqm_test_kit/v3.0.0/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/bulk_import_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe DEQMTestKit::BulkImport do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{bulk-import-id}` <- current naming convention
-  def test_by_id(group, bulk_import_id)
-    group.tests.find { |t| t.id.end_with?(bulk_import_id) }
-  end
-
   describe 'The server is able to accept bulk data import requests' do
     let(:test) { test_by_id(group, 'bulk-import-accepts-import-requests') }
 

--- a/spec/deqm_test_kit/v3.0.0/bulk_import_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/bulk_import_spec.rb
@@ -16,8 +16,14 @@ RSpec.describe DEQMTestKit::BulkImport do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{bulk-import-id}` <- current naming convention
+  def test_by_id(group, bulk_import_id)
+    group.tests.find { |t| t.id.end_with?(bulk_import_id) }
+  end
+
   describe 'The server is able to accept bulk data import requests' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'bulk-import-accepts-import-requests') }
 
     it 'passes on successful $import' do
       resource = FHIR::Bundle.new(total: 1, entry: [{ resource: { id: 'test_id' } }])

--- a/spec/deqm_test_kit/v3.0.0/bulk_submit_data_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/bulk_submit_data_spec.rb
@@ -17,8 +17,14 @@ RSpec.describe DEQMTestKit::BulkSubmitData do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{bulk-submit-data-id}` <- current naming convention
+  def test_by_id(group, bulk_submit_data_id)
+    group.tests.find { |t| t.id.end_with?(bulk_submit_data_id) }
+  end
+
   describe 'The server is able to perform bulk data tasks' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'bulk-submit-data-accepts-requests-for-measure') }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/v3.0.0/bulk_submit_data_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/bulk_submit_data_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe DEQMTestKit::BulkSubmitData do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{bulk-submit-data-id}` <- current naming convention
-  def test_by_id(group, bulk_submit_data_id)
-    group.tests.find { |t| t.id.end_with?(bulk_submit_data_id) }
-  end
-
   describe 'The server is able to perform bulk data tasks' do
     let(:test) { test_by_id(group, 'bulk-submit-data-accepts-requests-for-measure') }
     let(:measure_name) { 'EXM130' }

--- a/spec/deqm_test_kit/v3.0.0/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/care_gaps_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe DEQMTestKit::CareGaps do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{care-gaps-id}` <- current naming convention
-  def test_by_id(group, care_gaps_id)
-    group.tests.find { |t| t.id.end_with?(care_gaps_id) }
-  end
-
   describe '$care-gaps successful test with required query parameters (Patient)' do
     let(:test) { test_by_id(group, 'care-gaps-patient-subject-with-required-params') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/v3.0.0/care_gaps_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/care_gaps_spec.rb
@@ -18,8 +18,14 @@ RSpec.describe DEQMTestKit::CareGaps do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{care-gaps-id}` <- current naming convention
+  def test_by_id(group, care_gaps_id)
+    group.tests.find { |t| t.id.end_with?(care_gaps_id) }
+  end
+
   describe '$care-gaps successful test with required query parameters (Patient)' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'care-gaps-patient-subject-with-required-params') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -60,7 +66,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps successful test with Group subject' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'care-gaps-group-subject-with-required-params') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:group_id) { 'EXM130-patients' }
     let(:period_start) { '2019-01-01' }
@@ -101,7 +107,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps missing required parameter test' do
-    let(:test) { group.tests[2] }
+    let(:test) { test_by_id(group, 'care-gaps-missing-required-parameter') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_end) { '2019-12-31' }
@@ -138,7 +144,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps has subject and organization test' do
-    let(:test) { group.tests[3] }
+    let(:test) { test_by_id(group, 'care-gaps-subject-and-organization-conflict') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -177,7 +183,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps has invalid subject format test' do
-    let(:test) { group.tests[4] }
+    let(:test) { test_by_id(group, 'care-gaps-invalid-subject-format') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'INVALID_SUBJECT_ID' }
     let(:period_start) { '2019-01-01' }
@@ -216,7 +222,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps successful test with no measure identifier' do
-    let(:test) { group.tests[5] }
+    let(:test) { test_by_id(group, 'care-gaps-no-measure-identifier-provided') }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -236,7 +242,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps has invalid measure id test' do
-    let(:test) { group.tests[6] }
+    let(:test) { test_by_id(group, 'care-gaps-invalid-measure-identifier') }
     let(:measure_id) { 'INVALID_MEASURE_ID' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -277,7 +283,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps successful test with practitioner and organization' do
-    let(:test) { group.tests[7] }
+    let(:test) { test_by_id(group, 'care-gaps-practitioner-and-organization-params') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:practitioner_id) { '1' }
     let(:org_id) { '1' }
@@ -318,7 +324,7 @@ RSpec.describe DEQMTestKit::CareGaps do
   end
 
   describe '$care-gaps successful test with program' do
-    let(:test) { group.tests[8] }
+    let(:test) { test_by_id(group, 'care-gaps-with-program-parameter') }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }

--- a/spec/deqm_test_kit/v3.0.0/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/data_requirements_spec.rb
@@ -20,8 +20,14 @@ RSpec.describe DEQMTestKit::DataRequirements do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{data-requirements-id}` <- current naming convention
+  def test_by_id(group, data_requirements_id)
+    group.tests.find { |t| t.id.end_with?(data_requirements_id) }
+  end
+
   describe '$data-requirements matches reference results test' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'data-requirements-match-reference-server') }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
@@ -312,7 +318,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
   end
 
   describe '$data-requirements with period start and period end' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'data-requirements-with-period-parameters') }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
@@ -357,7 +363,7 @@ RSpec.describe DEQMTestKit::DataRequirements do
   end
 
   describe '$data-requirements with invalid id' do
-    let(:test) { group.tests[2] }
+    let(:test) { test_by_id(group, 'data-requirements-invalid-measure-returns-404') }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/v3.0.0/data_requirements_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/data_requirements_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe DEQMTestKit::DataRequirements do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{data-requirements-id}` <- current naming convention
-  def test_by_id(group, data_requirements_id)
-    group.tests.find { |t| t.id.end_with?(data_requirements_id) }
-  end
-
   describe '$data-requirements matches reference results test' do
     let(:test) { test_by_id(group, 'data-requirements-match-reference-server') }
     let(:measure_name) { 'EXM130' }

--- a/spec/deqm_test_kit/v3.0.0/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/evaluate_measure_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{evaluate-measure-id}` <- current naming convention
-  def test_by_id(group, evaluate_measure_id)
-    group.tests.find { |t| t.id.end_with?(evaluate_measure_id) }
-  end
-
   describe '$evaluate-measure successful individual report test' do
     let(:test) { test_by_id(group, 'evaluate-measure-individual-with-patient-subject') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/v3.0.0/evaluate_measure_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/evaluate_measure_spec.rb
@@ -21,8 +21,14 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{evaluate-measure-id}` <- current naming convention
+  def test_by_id(group, evaluate_measure_id)
+    group.tests.find { |t| t.id.end_with?(evaluate_measure_id) }
+  end
+
   describe '$evaluate-measure successful individual report test' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'evaluate-measure-individual-with-patient-subject') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -69,7 +75,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure successful subject-list report test' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'evaluate-measure-subject-list-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -117,7 +123,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure successful population report test' do
-    let(:test) { group.tests[2] }
+    let(:test) { test_by_id(group, 'evaluate-measure-population-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -162,7 +168,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure successful population report with Group subject test' do
-    let(:test) { group.tests[3] }
+    let(:test) { test_by_id(group, 'evaluate-measure-population-with-group-subject') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -229,7 +235,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
     end
   end
   describe '$evaluate-measure fails for invalid measure id' do
-    let(:test) { group.tests[4] }
+    let(:test) { test_by_id(group, 'evaluate-measure-invalid-measureid') }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -258,7 +264,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for invalid patient id' do
-    let(:test) { group.tests[5] }
+    let(:test) { test_by_id(group, 'evaluate-measure-invalid-patientid') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -287,7 +293,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for missing required params' do
-    let(:test) { group.tests[6] }
+    let(:test) { test_by_id(group, 'evaluate-measure-missing-period-start') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_end) { '2019-12-31' }
@@ -316,7 +322,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for missing subject param for individual report type' do
-    let(:test) { group.tests[7] }
+    let(:test) { test_by_id(group, 'evaluate-measure-missing-subject-param') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -345,7 +351,7 @@ RSpec.describe DEQMTestKit::EvaluateMeasure do
   end
 
   describe '$evaluate-measure fails for invalid reportType' do
-    let(:test) { group.tests[8] }
+    let(:test) { test_by_id(group, 'evaluate-measure-invalid-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }

--- a/spec/deqm_test_kit/v3.0.0/fhir_queries_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/fhir_queries_spec.rb
@@ -36,8 +36,14 @@ RSpec.describe DEQMTestKit::FHIRQueries do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{fhir-queries-id}` <- current naming convention
+  def test_by_id(group, fhir_queries_id)
+    group.tests.find { |t| t.id.end_with?(fhir_queries_id) }
+  end
+
   describe 'FHIR queries with successful $data-requirements request (all patients)' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'fhir-queries-all-patients-from-data-requirements') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:condition_id) { 'test-condition' }
     let(:period_start) { '2019-01-01' }
@@ -202,7 +208,7 @@ RSpec.describe DEQMTestKit::FHIRQueries do
   end
 
   describe 'FHIR queries with successful $data-requirements request (single patient)' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'fhir-queries-single-patient-from-data-requirements') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:condition_id) { 'test-condition' }
     let(:period_start) { '2019-01-01' }

--- a/spec/deqm_test_kit/v3.0.0/fhir_queries_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/fhir_queries_spec.rb
@@ -36,12 +36,6 @@ RSpec.describe DEQMTestKit::FHIRQueries do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{fhir-queries-id}` <- current naming convention
-  def test_by_id(group, fhir_queries_id)
-    group.tests.find { |t| t.id.end_with?(fhir_queries_id) }
-  end
-
   describe 'FHIR queries with successful $data-requirements request (all patients)' do
     let(:test) { test_by_id(group, 'fhir-queries-all-patients-from-data-requirements') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/v3.0.0/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/measure_availability_spec.rb
@@ -17,8 +17,14 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{measure-availability-id}` <- current naming convention
+  def test_by_id(group, measure_availability_id)
+    group.tests.find { |t| t.id.end_with?(measure_availability_id) }
+  end
+
   describe 'measure search test' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'measure-availability-found') }
     let(:selected_measure_id) { 'EXM130|7.3.000' }
     let(:measure_name) { 'EXM130' }
     let(:measure_version) { '7.3.000' }
@@ -79,4 +85,6 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
       expect(result.result_message).to match(/measure/)
     end
   end
+
+  # TODO: Add test for 'measure-availability-not-found'
 end

--- a/spec/deqm_test_kit/v3.0.0/measure_availability_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/measure_availability_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe DEQMTestKit::MeasureAvailability do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{measure-availability-id}` <- current naming convention
-  def test_by_id(group, measure_availability_id)
-    group.tests.find { |t| t.id.end_with?(measure_availability_id) }
-  end
-
   describe 'measure search test' do
     let(:test) { test_by_id(group, 'measure-availability-found') }
     let(:selected_measure_id) { 'EXM130|7.3.000' }

--- a/spec/deqm_test_kit/v3.0.0/patient_everything_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/patient_everything_spec.rb
@@ -19,12 +19,6 @@ RSpec.describe DEQMTestKit::PatientEverything do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{patient-everything-id}` <- current naming convention
-  def test_by_id(group, patient_everything_id)
-    group.tests.find { |t| t.id.end_with?(patient_everything_id) }
-  end
-
   describe 'Patient/<id>/$everything successful test' do
     let(:test) { test_by_id(group, 'patient-everything-single-patient') }
 

--- a/spec/deqm_test_kit/v3.0.0/patient_everything_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/patient_everything_spec.rb
@@ -19,8 +19,14 @@ RSpec.describe DEQMTestKit::PatientEverything do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{patient-everything-id}` <- current naming convention
+  def test_by_id(group, patient_everything_id)
+    group.tests.find { |t| t.id.end_with?(patient_everything_id) }
+  end
+
   describe 'Patient/<id>/$everything successful test' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'patient-everything-single-patient') }
 
     # single patient example for Patient/<id>/$everything
     single_patient_file = File.open('./lib/fixtures/singlePatientBundle.json')
@@ -63,7 +69,7 @@ RSpec.describe DEQMTestKit::PatientEverything do
   end
 
   describe 'Patient/$everything successful test' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'patient-everything-all-patients') }
 
     # multiple patient example for Patient/$everything
     multiple_patient_file = File.open('./lib/fixtures/multiplePatientBundle.json')
@@ -104,7 +110,7 @@ RSpec.describe DEQMTestKit::PatientEverything do
   end
 
   describe 'Patient/<id>/$everything fails for invalid id' do
-    let(:test) { group.tests[2] }
+    let(:test) { test_by_id(group, 'patient-everything-invalid-patient-id') }
 
     it 'passes with correct Operation-Outcome returned' do
       stub_request(:post, "#{url}/Patient/INVALID/$everything")

--- a/spec/deqm_test_kit/v3.0.0/submit_data_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/submit_data_spec.rb
@@ -18,8 +18,14 @@ RSpec.describe DEQMTestKit::SubmitData do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v300-{submit-data-id}` <- current naming convention
+  def test_by_id(group, submit_data_id)
+    group.tests.find { |t| t.id.end_with?(submit_data_id) }
+  end
+
   describe '$submit-data successful upload test' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'submit-data-valid-submission-with-verification') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
 
     it 'passes if the submitted resources can be retrieved' do
@@ -148,7 +154,7 @@ RSpec.describe DEQMTestKit::SubmitData do
     end
   end
   describe '$submit-data failed on Parameters object with no MeasureReport' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'submit-data-fails-missing-measurereport') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
 
     it 'passes when server returns 400 with correct operation outcome' do
@@ -184,7 +190,7 @@ RSpec.describe DEQMTestKit::SubmitData do
   end
 
   describe '$submit-data failed on Parameters object with multiple MeasureReports' do
-    let(:test) { group.tests[2] }
+    let(:test) { test_by_id(group, 'submit-data-fails-multiple-measurereports') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
 
     it 'passes when server returns 400 with correct operation outcome' do

--- a/spec/deqm_test_kit/v3.0.0/submit_data_spec.rb
+++ b/spec/deqm_test_kit/v3.0.0/submit_data_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe DEQMTestKit::SubmitData do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v300-{submit-data-id}` <- current naming convention
-  def test_by_id(group, submit_data_id)
-    group.tests.find { |t| t.id.end_with?(submit_data_id) }
-  end
-
   describe '$submit-data successful upload test' do
     let(:test) { test_by_id(group, 'submit-data-valid-submission-with-verification') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
@@ -33,8 +33,14 @@ RSpec.describe DEQMTestKit::Evaluate do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
+  # Helper method to find the spec file by name
+  # `deqm_v500-{evaluate-id}` <- current naming convention
+  def test_by_id(group, evaluate_id)
+    group.tests.find { |t| t.id.end_with?(evaluate_id) }
+  end
+
   describe 'Measure/[id]/$evaluate with reportType=population' do
-    let(:test) { group.tests.first }
+    let(:test) { test_by_id(group, 'evaluate-measureid-query-default-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -102,7 +108,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate with reportType=population' do
-    let(:test) { group.tests[1] }
+    let(:test) { test_by_id(group, 'evaluate-measureid-body-default-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -130,7 +136,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate with reportType=subject' do
-    let(:test) { group.tests[2] }
+    let(:test) { test_by_id(group, 'evaluate-subject-reporttype-body') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -159,7 +165,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe '$evaluate output with multiple measures using Measure/$evaluate' do
-    let(:test) { group.tests[3] }
+    let(:test) { test_by_id(group, 'evaluate-multiple-measureids-no-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:additional_measures) { ['measure-EXM124-7.3.000'] }
     let(:period_start) { '2019-01-01' }
@@ -224,7 +230,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe '$evaluate output with multiple measures using Measure/$evaluate and reportType=subject' do
-    let(:test) { group.tests[4] }
+    let(:test) { test_by_id(group, 'evaluate-multiple-measureids-with-subject') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:additional_measures) { ['measure-EXM124-7.3.000'] }
     let(:patient_id) { 'numer-EXM130' }
@@ -293,7 +299,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   ## TODO: write test for subjectGroup
 
   describe 'Measure/$evaluate with reportType=subject and subject Group reference' do
-    let(:test) { group.tests[6] }
+    let(:test) { test_by_id(group, 'evaluate-subjectgroup-reference') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:group_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -323,7 +329,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate reportType=subject fails for invalid measure id' do
-    let(:test) { group.tests[7] }
+    let(:test) { test_by_id(group, 'evaluate-invalid-measureid-subject') }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -369,7 +375,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/[id]/$evaluate fails for invalid measure ID' do
-    let(:test) { group.tests[8] }
+    let(:test) { test_by_id(group, 'evaluate-measureid-query-invalid-measureid') }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -400,7 +406,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate reportType=subject fails for invalid patient ID' do
-    let(:test) { group.tests[9] }
+    let(:test) { test_by_id(group, 'evaluate-invalid-patientid-subject-body') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -446,7 +452,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/[id]/$evaluate reportType=subject fails for invalid patient ID' do
-    let(:test) { group.tests[10] }
+    let(:test) { test_by_id(group, 'evaluate-measureid-query-invalid-patientid') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -489,7 +495,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/[id]/$evaluate fails for missing subject query parameter (subject report type)' do
-    let(:test) { group.tests[11] }
+    let(:test) { test_by_id(group, 'evaluate-missing-subject-param') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
@@ -517,7 +523,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/[id]/$evaluate reportType=subject fails for invalid reportType' do
-    let(:test) { group.tests[12] }
+    let(:test) { test_by_id(group, 'evaluate-measureid-query-invalid-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:params) do
@@ -561,7 +567,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate reportType=subject fails for invalid reportType' do
-    let(:test) { group.tests[13] }
+    let(:test) { test_by_id(group, 'evaluate-body-invalid-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -589,7 +595,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/[id]/$evaluate reportType=subject fails for missing periodEnd parameter in input' do
-    let(:test) { group.tests[14] }
+    let(:test) { test_by_id(group, 'evaluate-measureid-query-missing-periodend') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -608,7 +614,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate reportType=subject fails for missing periodEnd parameter' do
-    let(:test) { group.tests[15] }
+    let(:test) { test_by_id(group, 'evaluate-body-missing-periodend') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }

--- a/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe DEQMTestKit::Evaluate do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  # Helper method to find the spec file by name
-  # `deqm_v500-{evaluate-id}` <- current naming convention
-  def test_by_id(group, evaluate_id)
-    group.tests.find { |t| t.id.end_with?(evaluate_id) }
-  end
-
   describe 'Measure/[id]/$evaluate with reportType=population' do
     let(:test) { test_by_id(group, 'evaluate-measureid-query-default-reporttype') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,6 +137,12 @@ FactoryBot.definition_file_paths = [
 
 RSpec::Matchers.define_negated_matcher :exclude, :include
 
+# Helper method to find tests by their descriptive ID suffix
+# Usage: test_by_id(group, 'test-descriptive-name')
+def test_by_id(group, test_id_suffix)
+  group.tests.find { |t| t.id.end_with?(test_id_suffix) }
+end
+
 FHIR.logger = Inferno::Application['logger']
 
 DatabaseCleaner[:sequel].strategy = :truncation


### PR DESCRIPTION
# Summary

Updated all the id of the tests so that we no longer have to rely on numbering and making sure the spec tests are in the correct order. This helps with when we want to add a new test we can easily update the spec test without having to renumber everything else. 

Noticed while going through the Ids that we are missing tests for `measure-availability-not-found' and for `evaluate-subjectgroup-embedded-resource`. Not sure if this is by choice but happy to add them in if we desire. 

## New behavior

This update should not effect behavior at all. 

## Code changes

 Updated Test Files:


  1. `evaluate.rb`: Updated 16 test IDs 
  2. `patient_everything.rb`: Updated 3 test IDs 
  3. `measure_availability.rb`: Updated 2 test IDs
  4. `data_requirements.rb`: Updated 3 test IDs 
  5. `submit_data.rb`: Updated 3 test IDs 
  6. `fhir_queries.rb`: Updated 2 test IDs 
  7. `bulk_submit_data.rb`: Updated 1 test ID
  8. `bulk_import.rb`: Updated 1 test ID
  9. `evaluate_measure.rb`: Updated 11 test IDs
  10. `care_gaps.rb`: Updated 9 test IDs

  Updated Spec Files:

 -  All corresponding spec test files were updated to with matching ids
 -  Added a helper function in `spec_helper.rb` to handle the prefix that is prepended (ie `deqm_v500`) 

# Testing guidance

- Run the spec tests: `bundle exec rspec` <- They should all pass
- `ASYNC_JOBS=false bundle exec puma` to run the test kit locally, all tests should run as normal