### PR TITLE
Added subjectGroup tests, fixed evaluate tests

### DIFF
--- a/config/presets/deqm_v500_qtas_image_suite.json
+++ b/config/presets/deqm_v500_qtas_image_suite.json
@@ -15,7 +15,14 @@
       "description": "",
       "title": "",
       "type": "radio",
-      "value": "ColorectalCancerScreeningsFHIR&version=0.0.003"
+      "value": "CervicalCancerScreeningFHIR"
+    },
+    {
+      "name": "additional_measures",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": ["ColorectalCancerScreeningsFHIR"]
     },
     {
       "name": "data_requirements_reference_server",
@@ -36,14 +43,28 @@
       "description": "",
       "title": "",
       "type": "text",
-      "value": "numer-EXM130"
+      "value": "denom-EXM124"
+    },
+    {
+      "name": "patient_id_2",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "numer-EXM124"
+    },
+    {
+      "name": "group_subjects",
+      "description": "",
+      "title": "Number of subjects in the provided Group",
+      "type": "text",
+      "value": "2"
     },
     {
       "name": "group_id",
       "description": "",
       "title": "Group ID",
       "type": "text",
-      "value": "EXM130-patients"
+      "value": "EXM124-patients"
     },
     {
       "name": "practitioner_id",

--- a/config/presets/deqm_v500_qtas_image_suite.json
+++ b/config/presets/deqm_v500_qtas_image_suite.json
@@ -15,14 +15,14 @@
       "description": "",
       "title": "",
       "type": "radio",
-      "value": "CervicalCancerScreeningFHIR"
+      "value": "CMS506FHIRSafeUseofOpioids"
     },
     {
       "name": "additional_measures",
       "description": "",
       "title": "",
       "type": "radio",
-      "value": ["ColorectalCancerScreeningsFHIR"]
+      "value": ["CMS130FHIRColorectalCancerScreening"]
     },
     {
       "name": "data_requirements_reference_server",
@@ -43,28 +43,28 @@
       "description": "",
       "title": "",
       "type": "text",
-      "value": "denom-EXM124"
+      "value": "031889e2-0353-4c2e-82c0-f422e15aacaa"
     },
     {
       "name": "patient_id2",
       "description": "",
       "title": "",
       "type": "text",
-      "value": "numer-EXM124"
+      "value": "029865cf-b060-4024-be84-bb902726c25e"
     },
     {
       "name": "group_subjects",
       "description": "",
       "title": "Number of subjects in the provided Group",
       "type": "text",
-      "value": "2"
+      "value": "51"
     },
     {
       "name": "group_id",
       "description": "",
       "title": "Group ID",
       "type": "text",
-      "value": "EXM124-patients"
+      "value": "CMS506FHIRSafeUseofOpioids"
     },
     {
       "name": "practitioner_id",

--- a/config/presets/deqm_v500_qtas_image_suite.json
+++ b/config/presets/deqm_v500_qtas_image_suite.json
@@ -46,7 +46,7 @@
       "value": "denom-EXM124"
     },
     {
-      "name": "patient_id_2",
+      "name": "patient_id2",
       "description": "",
       "title": "",
       "type": "text",

--- a/config/presets/deqm_v500_test_server_local_suite.json
+++ b/config/presets/deqm_v500_test_server_local_suite.json
@@ -46,7 +46,7 @@
       "value": "denom-EXM124"
     },
     {
-      "name": "patient_id_2",
+      "name": "patient_id2",
       "description": "",
       "title": "",
       "type": "text",

--- a/config/presets/deqm_v500_test_server_local_suite.json
+++ b/config/presets/deqm_v500_test_server_local_suite.json
@@ -11,18 +11,18 @@
       "value": "http://localhost:3000/4_0_1"
     },
     {
-      "name": "selected_measure_id",
-      "description": "",
-      "title": "",
-      "type": "radio",
-      "value": "CervicalCancerScreeningFHIR|0.0.005"
-    },
-    {
       "name": "measure_id",
       "description": "",
       "title": "",
       "type": "radio",
-      "value": "CervicalCancerScreeningFHIR|0.0.005"
+      "value": "CervicalCancerScreeningFHIR"
+    },
+    {
+      "name": "additional_measures",
+      "description": "",
+      "title": "",
+      "type": "checkbox",
+      "value": ["ColorectalCancerScreeningsFHIR"]
     },
     {
       "name": "data_requirements_reference_server",
@@ -46,11 +46,25 @@
       "value": "denom-EXM124"
     },
     {
+      "name": "patient_id_2",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "numer-EXM124"
+    },
+    {
       "name": "group_id",
       "description": "",
       "title": "Group ID",
       "type": "text",
-      "value": "Cervical-patients"
+      "value": "EXM124-patients"
+    },
+    {
+      "name": "group_subjects",
+      "description": "",
+      "title": "Number of subjects in the provided Group",
+      "type": "text",
+      "value": "2"
     },
     {
       "name": "practitioner_id",

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -91,7 +91,7 @@ module DEQMTestKit
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/[id]/$evaluate (default reportType=population)'
-      id 'evaluate-measureid-path-default-reporttype'
+      id 'evaluate-id-path-population'
       description %(Measure/[id]/$evaluate without reportType (defaults to reportType=population)
       returns 200 and FHIR Parameters resource.)
 
@@ -126,10 +126,10 @@ module DEQMTestKit
 
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
-      title 'Measure/$evaluate with measureId in Parameters resource request body without reportType (defaults to reportType=population)' # rubocop:disable Layout/LineLength
-      id 'evaluate-measureid-body-default-reporttype'
-      description %(Measure/$evaluate with measureId in Parameters resource request body and
-      without reportType (defaults to reportType=population) returns 200 and FHIR Parameters resource.)
+      title 'Measure/$evaluate without reportType (defaults to reportType=population)'
+      id 'evaluate-population'
+      description %(Measure/$evaluate without reportType (defaults to reportType=population) returns 200
+      and FHIR Parameters resource.)
 
       input :measure_id, **measure_id_args
       input :custom_measure_id, **custom_measure_id_args
@@ -166,10 +166,10 @@ module DEQMTestKit
 
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
-      title 'Measure/$evaluate with reportType=subject and measureId in Parameters resource request body'
-      id 'evaluate-subject-reporttype-body'
-      description %(Measure/$evaluate with reportType=subject and subject and measureId in Parameters resource request
-      body returns 200 and FHIR Parameters resource.)
+      title 'Measure/$evaluate with reportType=subject and Patient subject'
+      id 'evaluate-subject-patient'
+      description %(Measure/$evaluate with reportType=subject and Patient subject returns
+      200 and FHIR Parameters resource.)
 
       input :measure_id, **measure_id_args
       input :custom_measure_id, **custom_measure_id_args
@@ -211,17 +211,17 @@ module DEQMTestKit
 
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
-      title 'Measure/$evaluate with multiple measureIds in Parameters resource request body without reportType (defaults to reportType=population)' # rubocop:disable Layout/LineLength
-      id 'evaluate-multiple-measureids-default-reporttype'
-      description %(Measure/$evaluate without reportType (defaults to reportType=population) and subject and multiple
-      measureIds in Parameters resource request body returns 200 and FHIR Parameters resource.)
+      title 'Measure/$evaluate with multiple measureIds without reportType (defaults to reportType=population)'
+      id 'evaluate-multiple-measure-population'
+      description %(Measure/$evaluate with multiple measureIds without reportType (defaults to reportType=population)
+      returns 200 and FHIR Parameters resource.)
       input :measure_id, **measure_id_args
       input :custom_measure_id, **custom_measure_id_args
       input :additional_measures, **additional_measures_args
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
       input :period_end, title: 'Measurement period end', default: '2026-12-31'
 
-      run do
+      run do # rubocop:disable Metrics/BlockLength
         measure_ids = [selected_measure_id]
         measure_ids += additional_measures if additional_measures&.any?
 
@@ -249,19 +249,23 @@ module DEQMTestKit
 
         validate_parameters_contains_measurereport_bundles(resource)
 
-        # Verify we have the expected number of bundles for each measure
-        expected_bundle_count = measure_ids.length
-        assert resource.parameter[0].resource.entry.length >= expected_bundle_count,
-               "Expected at #{expected_bundle_count} bundles, got #{resource.parameter[0].resource.entry.length}"
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 1,
+               "Expected 1 Bundle for reportType=population and no subjects specified, got #{resource.parameter.length}"
+
+        expected_measure_report_count = measure_ids.length
+        assert resource.parameter[0].resource.entry.length >= expected_measure_report_count,
+               "Expected #{expected_measure_report_count} MeasureReports, got
+               #{resource.parameter[0].resource.entry.length}"
       end
     end
 
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
-      title 'Measure/$evaluate with reportType=subject and multiple measureIds in Parameters resource request body'
-      id 'evaluate-multiple-measureids-with-subject'
-      description %(Measure/$evaluate with reportType=subject and subject and multiple measureIds in Parameters
-      resource request body returns 200 and FHIR Parameters resource.)
+      title 'Measure/$evaluate with multiple measureIds and reportType=subject and Patient subject'
+      id 'evaluate-multiple-measure-subject-patient'
+      description %(Measure/$evaluate with multiple measureIds and reportType=subject and subject Patient
+      returns 200 and FHIR Parameters resource.)
       input :measure_id, **measure_id_args
       input :custom_measure_id, **custom_measure_id_args
       input :additional_measures, **additional_measures_args
@@ -269,7 +273,7 @@ module DEQMTestKit
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
       input :period_end, title: 'Measurement period end', default: '2026-12-31'
 
-      run do
+      run do # rubocop:disable Metrics/BlockLength
         measure_ids = [selected_measure_id]
         measure_ids += additional_measures if additional_measures&.any?
 
@@ -298,22 +302,28 @@ module DEQMTestKit
 
         validate_parameters_contains_measurereport_bundles(resource)
 
-        # Verify we have the expected number of bundles for each measure
-        expected_bundle_count = measure_ids.length
-        assert resource.parameter[0].resource.entry.length >= expected_bundle_count,
-               "Expected at #{expected_bundle_count} bundles, got #{resource.parameter[0].resource.entry.length}"
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 1,
+               "Expected 1 Bundle for reportType=subject and 1 patient specified, got #{resource.parameter.length}"
+
+        expected_measure_report_count = measure_ids.length
+        assert resource.parameter[0].resource.entry.length >= expected_measure_report_count,
+               "Expected #{expected_measure_report_count} MeasureReports,
+               got #{resource.parameter[0].resource.entry.length}"
       end
     end
 
+    # POPULATION
+    # SUBJECTGROUP 2 PATIENTS
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
-      title 'Measure/$evaluate with reportType=subject and subjectGroup'
-      id 'evaluate-subjectgroup-embedded-resource'
-      description %(Measure/$evaluate with reportType=subject and subjectGroup.)
+      title 'Measure/$evaluate with reportType=population and subjectGroup with 2 Patients'
+      id 'evaluate-subject-group-resource-2-patients-population'
+      description %(Measure/$evaluate with reportType=population and subjectGroup with 2 Patients.)
       input :measure_id, **measure_id_args
       input :custom_measure_id, **custom_measure_id_args
       input :patient_id, title: 'Patient ID'
-      input :group_id, title: 'Group ID'
+      input :patient_id2, title: 'Patient ID 2'
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
       input :period_end, title: 'Measurement period end', default: '2026-12-31'
 
@@ -324,6 +334,236 @@ module DEQMTestKit
             {
               name: 'measureId',
               valueString: selected_measure_id
+            },
+            {
+              name: 'subject',
+              valueString: 'Group/test-group-2-subjects'
+            },
+            {
+              name: 'subjectGroup',
+              resource: {
+                resourceType: 'Group',
+                id: 'test-group-2-subjects',
+                member: [
+                  {
+                    entity: {
+                      reference: "Patient/#{patient_id}"
+                    }
+                  },
+                  {
+                    entity: {
+                      reference: "Patient/#{patient_id_2}"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              name: 'reportType',
+              valueString: 'population'
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+        fhir_operation('/Measure/$evaluate', body:)
+
+        assert_response_status(200)
+
+        assert resource.is_a?(FHIR::Parameters),
+               "Expected resource to be a Parameters resource, but got #{resource&.class}"
+
+        validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 1,
+               "Expected 1 Bundle for 2 patients specified in subjectGroup for reportType=population,
+               got #{resource.parameter.length}"
+
+        assert resource.parameter[0].resource.entry.length == 1,
+               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+      end
+    end
+
+    # SUBJECT
+    # SUBJECTGROUP 2 PATIENTS
+    test do # rubocop:disable Metrics/BlockLength
+      include MeasureEvaluationHelpers
+      title 'Measure/$evaluate with reportType=subject and subjectGroup with 2 Patients'
+      id 'evaluate-subject-group-resource-2-patients-subject'
+      description %(Measure/$evaluate with reportType=subject and subjectGroup with 2 Patients.)
+      input :measure_id, **measure_id_args
+      input :custom_measure_id, **custom_measure_id_args
+      input :patient_id, title: 'Patient ID'
+      input :patient_id2, title: 'Patient ID 2'
+      input :period_start, title: 'Measurement period start', default: '2026-01-01'
+      input :period_end, title: 'Measurement period end', default: '2026-12-31'
+
+      run do # rubocop:disable Metrics/BlockLength
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'measureId',
+              valueString: selected_measure_id
+            },
+            {
+              name: 'subject',
+              valueString: 'Group/test-group-2-subjects'
+            },
+            {
+              name: 'subjectGroup',
+              resource: {
+                resourceType: 'Group',
+                id: 'test-group-2-subjects',
+                member: [
+                  {
+                    entity: {
+                      reference: "Patient/#{patient_id}"
+                    }
+                  },
+                  {
+                    entity: {
+                      reference: "Patient/#{patient_id_2}"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              name: 'reportType',
+              valueString: 'subject'
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+        fhir_operation('/Measure/$evaluate', body:)
+
+        assert_response_status(200)
+
+        assert resource.is_a?(FHIR::Parameters),
+               "Expected resource to be a Parameters resource, but got #{resource&.class}"
+
+        validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 2,
+               "Expected 2 Bundles for 2 patients specified in subjectGroup, got #{resource.parameter.length}"
+
+        assert resource.parameter[0].resource.entry.length == 1,
+               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+      end
+    end
+
+    # POPULATION
+    # SUBJECTGROUP 1 PATIENT
+    test do # rubocop:disable Metrics/BlockLength
+      include MeasureEvaluationHelpers
+      title 'Measure/$evaluate with reportType=population and subjectGroup with 1 Patient'
+      id 'evaluate-subject-group-resource-1-patient-population'
+      description %(Measure/$evaluate with reportType=population and subjectGroup with 1 Patient.)
+      input :measure_id, **measure_id_args
+      input :custom_measure_id, **custom_measure_id_args
+      input :patient_id, title: 'Patient ID'
+      input :period_start, title: 'Measurement period start', default: '2026-01-01'
+      input :period_end, title: 'Measurement period end', default: '2026-12-31'
+
+      run do # rubocop:disable Metrics/BlockLength
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'measureId',
+              valueString: selected_measure_id
+            },
+            {
+              name: 'subject',
+              valueString: 'Group/test-group'
+            },
+            {
+              name: 'subjectGroup',
+              resource: {
+                resourceType: 'Group',
+                id: 'test-group',
+                member: [
+                  {
+                    entity: {
+                      reference: "Patient/#{patient_id}"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              name: 'reportType',
+              valueString: 'population'
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+        fhir_operation('/Measure/$evaluate', body:)
+
+        assert_response_status(200)
+
+        assert resource.is_a?(FHIR::Parameters),
+               "Expected resource to be a Parameters resource, but got #{resource&.class}"
+
+        validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 1,
+               "Expected 1 Bundle for reportType=subject and 1 patient specified in subjectGroup with
+               reportType=population, got #{resource.parameter.length}"
+
+        assert resource.parameter[0].resource.entry.length == 1,
+               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+      end
+    end
+
+    # SUBJECT
+    # SUBJECTGROUP 1 PATIENT
+    test do # rubocop:disable Metrics/BlockLength
+      include MeasureEvaluationHelpers
+      title 'Measure/$evaluate with reportType=subject and subjectGroup with 1 Patient'
+      id 'evaluate-subject-group-resource-1-patient-subject'
+      description %(Measure/$evaluate with reportType=subject and subjectGroup with 1 Patient.)
+      input :measure_id, **measure_id_args
+      input :custom_measure_id, **custom_measure_id_args
+      input :patient_id, title: 'Patient ID'
+      input :period_start, title: 'Measurement period start', default: '2026-01-01'
+      input :period_end, title: 'Measurement period end', default: '2026-12-31'
+
+      run do # rubocop:disable Metrics/BlockLength
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'measureId',
+              valueString: selected_measure_id
+            },
+            {
+              name: 'subject',
+              valueString: 'Group/test-group'
             },
             {
               name: 'subjectGroup',
@@ -361,17 +601,82 @@ module DEQMTestKit
                "Expected resource to be a Parameters resource, but got #{resource&.class}"
 
         validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 1,
+               "Expected 1 Bundle for reportType=subject and 1 patient specified in subjectGroup for
+               reportType=subject, got #{resource.parameter.length}"
+
+        assert resource.parameter[0].resource.entry.length == 1,
+               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
       end
     end
 
+    # POPULATION
+    # GROUP REFERENCE
+    test do # rubocop:disable Metrics/BlockLength
+      include MeasureEvaluationHelpers
+      title 'Measure/$evaluate with reportType=population and subject Group reference'
+      id 'evaluate-subject-group-reference-population'
+      description %(Measure/$evaluate with reportType=population and subject Group reference.)
+      input :measure_id, **measure_id_args
+      input :custom_measure_id, **custom_measure_id_args
+      input :group_id, title: 'Group ID'
+      input :period_start, title: 'Measurement period start', default: '2026-01-01'
+      input :period_end, title: 'Measurement period end', default: '2026-12-31'
+
+      run do # rubocop:disable Metrics/BlockLength
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'subject',
+              valueString: "Group/#{group_id}"
+            },
+            {
+              name: 'measureId',
+              valueString: selected_measure_id
+            },
+            {
+              name: 'reportType',
+              valueString: 'population'
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+        fhir_operation('/Measure/$evaluate', body:)
+
+        assert_response_status(200)
+
+        assert resource.is_a?(FHIR::Parameters),
+               "Expected resource to be a Parameters resource, but got #{resource&.class}"
+
+        validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length == 1,
+               "Expected 1 Bundle, got #{resource.parameter.length}"
+      end
+    end
+
+    # SUBJECT
+    # GROUP REFERENCE
     test do # rubocop:disable Metrics/BlockLength
       include MeasureEvaluationHelpers
       title 'Measure/$evaluate with reportType=subject and subject Group reference'
-      id 'evaluate-subjectgroup-reference'
+      id 'evaluate-subject-group-reference-subject'
       description %(Measure/$evaluate with reportType=subject and subject Group reference.)
       input :measure_id, **measure_id_args
       input :custom_measure_id, **custom_measure_id_args
       input :group_id, title: 'Group ID'
+      input :group_subjects, title: 'Number of subjects in the provided Group'
       input :period_start, title: 'Measurement period start', default: '2026-01-01'
       input :period_end, title: 'Measurement period end', default: '2026-12-31'
 
@@ -409,6 +714,11 @@ module DEQMTestKit
                "Expected resource to be a Parameters resource, but got #{resource&.class}"
 
         validate_parameters_contains_measurereport_bundles(resource)
+
+        # Verify we have the expected number of bundles for each subject
+        assert resource.parameter.length.to_s == group_subjects,
+               "Expected #{group_subjects} Bundles for each subject specified in the referenced Group,
+                got #{resource.parameter.length}"
       end
     end
 

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -253,11 +253,12 @@ module DEQMTestKit
         assert resource.parameter.length == 1,
                "Expected 1 Bundle for reportType=population and no subjects specified, got #{resource.parameter.length}"
 
+        expected_measure_report_count = measure_ids.length
         measure_reports = resource.parameter[0].resource.entry.select do |entry|
           entry.resource.resourceType == 'MeasureReport'
         end
-        assert measure_reports.length == 1,
-               "Expected 1 MeasureReport, got #{measure_reports.length}"
+        assert measure_reports.length == expected_measure_report_count,
+               "Expected #{expected_measure_report_count} MeasureReports, got #{measure_reports.length}"
       end
     end
 

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -352,7 +352,7 @@ module DEQMTestKit
                   },
                   {
                     entity: {
-                      reference: "Patient/#{patient_id_2}"
+                      reference: "Patient/#{patient_id2}"
                     }
                   }
                 ]
@@ -430,7 +430,7 @@ module DEQMTestKit
                   },
                   {
                     entity: {
-                      reference: "Patient/#{patient_id_2}"
+                      reference: "Patient/#{patient_id2}"
                     }
                   }
                 ]

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -253,10 +253,11 @@ module DEQMTestKit
         assert resource.parameter.length == 1,
                "Expected 1 Bundle for reportType=population and no subjects specified, got #{resource.parameter.length}"
 
-        expected_measure_report_count = measure_ids.length
-        assert resource.parameter[0].resource.entry.length >= expected_measure_report_count,
-               "Expected #{expected_measure_report_count} MeasureReports, got
-               #{resource.parameter[0].resource.entry.length}"
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == 1,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -307,9 +308,11 @@ module DEQMTestKit
                "Expected 1 Bundle for reportType=subject and 1 patient specified, got #{resource.parameter.length}"
 
         expected_measure_report_count = measure_ids.length
-        assert resource.parameter[0].resource.entry.length >= expected_measure_report_count,
-               "Expected #{expected_measure_report_count} MeasureReports,
-               got #{resource.parameter[0].resource.entry.length}"
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == expected_measure_report_count,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -386,8 +389,11 @@ module DEQMTestKit
                "Expected 1 Bundle for 2 patients specified in subjectGroup for reportType=population,
                got #{resource.parameter.length}"
 
-        assert resource.parameter[0].resource.entry.length == 1,
-               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == 1,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -463,8 +469,11 @@ module DEQMTestKit
         assert resource.parameter.length == 2,
                "Expected 2 Bundles for 2 patients specified in subjectGroup, got #{resource.parameter.length}"
 
-        assert resource.parameter[0].resource.entry.length == 1,
-               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == 1,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -532,11 +541,14 @@ module DEQMTestKit
 
         # Verify we have the expected number of bundles for each subject
         assert resource.parameter.length == 1,
-               "Expected 1 Bundle for reportType=subject and 1 patient specified in subjectGroup with
-               reportType=population, got #{resource.parameter.length}"
+               "Expected 1 Bundle for reportType=population with 1 patient specified in subjectGroup,
+                got #{resource.parameter.length}"
 
-        assert resource.parameter[0].resource.entry.length == 1,
-               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == 1,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -604,11 +616,14 @@ module DEQMTestKit
 
         # Verify we have the expected number of bundles for each subject
         assert resource.parameter.length == 1,
-               "Expected 1 Bundle for reportType=subject and 1 patient specified in subjectGroup for
-               reportType=subject, got #{resource.parameter.length}"
+               "Expected 1 Bundle for reportType=subject and 1 patient specified in subjectGroup,
+                got #{resource.parameter.length}"
 
-        assert resource.parameter[0].resource.entry.length == 1,
-               "Expected 1 MeasureReport, got #{resource.parameter[0].resource.entry.length}"
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == 1,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -663,6 +678,12 @@ module DEQMTestKit
         # Verify we have the expected number of bundles for each subject
         assert resource.parameter.length == 1,
                "Expected 1 Bundle, got #{resource.parameter.length}"
+
+        measure_reports = resource.parameter[0].resource.entry.select do |entry|
+          entry.resource.resourceType == 'MeasureReport'
+        end
+        assert measure_reports.length == 1,
+               "Expected 1 MeasureReport, got #{measure_reports.length}"
       end
     end
 
@@ -719,6 +740,11 @@ module DEQMTestKit
         assert resource.parameter.length.to_s == group_subjects,
                "Expected #{group_subjects} Bundles for each subject specified in the referenced Group,
                 got #{resource.parameter.length}"
+
+        resource.parameter.each do |param|
+          measure_reports = param.resource.entry.select { |entry| entry.resource.resourceType == 'MeasureReport' }
+          assert measure_reports.length == 1, "Expected 1 MeasureReport in each Bundle, got #{measure_reports.length}"
+        end
       end
     end
 

--- a/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
@@ -165,26 +165,18 @@ RSpec.describe DEQMTestKit::Evaluate do
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
 
-    it 'passes with correct Parameters resource containing multiple bundles' do
-      # Create a Parameters response with a single bundle containing multiple entries
+    it 'passes with correct Parameters resource containing one Bundle with one MeasureReport' do
       measure_report_first = FHIR::MeasureReport.new(
-        status: 'complete', type: 'individual',
+        status: 'complete', type: 'summary',
         measure: measure_id,
         period: { start: period_start, end: period_end }
       )
-      measure_report_second = FHIR::MeasureReport.new(
-        status: 'complete', type: 'individual',
-        measure: additional_measures.first,
-        period: { start: period_start, end: period_end }
-      )
       bundle = FHIR::Bundle.new(type: 'collection', entry: [
-                                  { resource: measure_report_first },
-                                  { resource: measure_report_second }
+                                  { resource: measure_report_first }
                                 ])
       parameters_response = FHIR::Parameters.new(parameter: [
                                                    { resource: bundle }
                                                  ])
-
       stub_request(
         :post,
         "#{url}/Measure/$evaluate"
@@ -231,7 +223,7 @@ RSpec.describe DEQMTestKit::Evaluate do
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
 
-    it 'passes with correct Parameters resource containing multiple bundles' do
+    it 'passes with correct Parameters resource 1 Bundle with 2 MeasureReports' do
       # Create a Parameters response with a single bundle containing multiple entries
       measure_report_first = FHIR::MeasureReport.new(
         status: 'complete', type: 'individual',

--- a/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
@@ -171,8 +171,14 @@ RSpec.describe DEQMTestKit::Evaluate do
         measure: measure_id,
         period: { start: period_start, end: period_end }
       )
+      measure_report_second = FHIR::MeasureReport.new(
+        status: 'complete', type: 'individual',
+        measure: additional_measures.first,
+        period: { start: period_start, end: period_end }
+      )
       bundle = FHIR::Bundle.new(type: 'collection', entry: [
-                                  { resource: measure_report_first }
+                                  { resource: measure_report_first },
+                                  { resource: measure_report_second }
                                 ])
       parameters_response = FHIR::Parameters.new(parameter: [
                                                    { resource: bundle }

--- a/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v5.0.0/evaluate_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/[id]/$evaluate with reportType=population' do
-    let(:test) { test_by_id(group, 'evaluate-measureid-path-default-reporttype') }
+    let(:test) { test_by_id(group, 'evaluate-id-path-population') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -102,7 +102,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate with reportType=population' do
-    let(:test) { test_by_id(group, 'evaluate-measureid-body-default-reporttype') }
+    let(:test) { test_by_id(group, 'evaluate-population') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -130,7 +130,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe 'Measure/$evaluate with reportType=subject' do
-    let(:test) { test_by_id(group, 'evaluate-subject-reporttype-body') }
+    let(:test) { test_by_id(group, 'evaluate-subject-patient') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:patient_id) { 'numer-EXM130' }
     let(:period_start) { '2019-01-01' }
@@ -159,7 +159,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe '$evaluate output with multiple measures using Measure/$evaluate' do
-    let(:test) { test_by_id(group, 'evaluate-multiple-measureids-default-reporttype') }
+    let(:test) { test_by_id(group, 'evaluate-multiple-measure-population') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:additional_measures) { ['measure-EXM124-7.3.000'] }
     let(:period_start) { '2019-01-01' }
@@ -224,7 +224,7 @@ RSpec.describe DEQMTestKit::Evaluate do
   end
 
   describe '$evaluate output with multiple measures using Measure/$evaluate and reportType=subject' do
-    let(:test) { test_by_id(group, 'evaluate-multiple-measureids-with-subject') }
+    let(:test) { test_by_id(group, 'evaluate-multiple-measure-subject-patient') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:additional_measures) { ['measure-EXM124-7.3.000'] }
     let(:patient_id) { 'numer-EXM130' }
@@ -293,9 +293,10 @@ RSpec.describe DEQMTestKit::Evaluate do
   ## TODO: write test for subjectGroup
 
   describe 'Measure/$evaluate with reportType=subject and subject Group reference' do
-    let(:test) { test_by_id(group, 'evaluate-subjectgroup-reference') }
+    let(:test) { test_by_id(group, 'evaluate-subject-group-reference-subject') }
     let(:measure_id) { 'measure-EXM130-7.3.000' }
     let(:group_id) { 'numer-EXM130' }
+    let(:group_subjects) { '1' }
     let(:period_start) { '2019-01-01' }
     let(:period_end) { '2019-12-31' }
 
@@ -316,7 +317,7 @@ RSpec.describe DEQMTestKit::Evaluate do
       )
         .to_return(status: 200, body: parameters_response.to_json, headers: {})
 
-      result = run(test, url:, measure_id:, group_id:, period_start:, period_end:)
+      result = run(test, url:, measure_id:, group_subjects:, period_start:, period_end:, group_id:)
       expect(result.result).to eq('pass')
     end
   end


### PR DESCRIPTION
# Summary
This PR cleans up some of the $evaluate that I had incorrectly implemented and adds more subject and subjectGroup tests.

## New behavior
- There are 6 tests where a Group is either passed in as a reference in `subject` or as an entire resource in `subjectGroup` (reference to that `subjectGroup` is still required in `subject` when `subjectGroup` is present):

3 tests where reportType=population:
    - Measure/$evaluate with ONLY subject=Group/group_id (group reference)
    - Measure/$evaluate with subject=Group/embedded_group_id and subjectGroup=Group resource with 1 Patient
    - Measure/$evaluate with subject=Group/embdedded_group_id and subjectGroup=Group resource with 2 Patients

3 tests where reportType=subject (these will fail in deqm-test-server):
    - Measure/$evaluate with ONLY subject=Group/group_id (group reference)
    - Measure/$evaluate with subject=Group/embedded_group_id and subjectGroup=Group resource with 1 Patient
    - Measure/$evaluate with subject=Group/embdedded_group_id and subjectGroup=Group resource with 2 Patients

Fixes to multi measure $evaluate tests:
Two tests with multiple measureIds:

1. reportType=population
    - Should return Parameters resource with 1 Bundle that contains x MeasureReports (where x is the number of measureIds)
3. reportType=subject
    - Should return Parameters resource with 1 Bundle that contains x MeasureReports (where x is the number of measureIds)

## Code changes
- `config/presets` - added/fixed DEQM Test Server Local and QTAS image present (don't worry about QTAS image one)
- `lib/deqm_test_kit/evaluate.rb` - changes reflecting above changes

# Testing guidance
- `bundle exec rubocop`
- `bundle exec rspec` NOTE: I didn't add or improve any spec tests, just fixed them.
- Run the deqm-test-server on [this deqm-test-server branch](https://github.com/projecttacoma/deqm-test-server/pull/170) (`npm run start`)
- Run the $evaluate tests on the DEQM STU5 test suite with the DEQM Test Server Local preset. Make sure that the deqm-test-server is loaded with bundles. You will also need to create the EXM124-patients Group- send a PUT request to `http://localhost:3000/4_0_1/Group/EXM124-patients` with Content-Type as application/json+fhir in the headers and the following JSON body:

```
{
	"resourceType": "Group",
	"id": "EXM124-patients",
	"type": "person",
	"actual": "true",
	"member": [
		{
			"entity": {
				"reference": "Patient/denom-EXM124"
			}
		},
		{
			"entity": {
				"reference": "Patient/numer-EXM124"
			}
		}
	]
}
```
- NOTE: 3 tests _should_ fail with deqm-test-server as the subject=Group with reportType=subject is not yet implemented. Everything else should pass.
- I changed a lot of the descriptions and test ids etc. so make sure that test titles, descriptions, and functionality all line up.