### PR TITLE
Fix submit-data and evaluate tests for v5

### DIFF
--- a/config/presets/deqm_v500_flame_demo_test_server_suite.json
+++ b/config/presets/deqm_v500_flame_demo_test_server_suite.json
@@ -15,14 +15,14 @@
       "description": "",
       "title": "",
       "type": "radio",
-      "value": "CervicalCancerScreeningFHIR|0.0.005"
+      "value": "CMS0334FHIRPCCesareanBirth"
     },
     {
       "name": "measure_id",
       "description": "",
       "title": "",
       "type": "radio",
-      "value": "CervicalCancerScreeningFHIR|0.0.005"
+      "value": "CMS0334FHIRPCCesareanBirth"
     },
     {
       "name": "data_requirements_reference_server",
@@ -43,14 +43,28 @@
       "description": "",
       "title": "",
       "type": "text",
-      "value": "942960c8-37da-492d-85c8-0271d7b655b2"
+      "value": "f6dafa7e-15a9-4fec-baea-59d43201caf8"
+    },
+    {
+      "name": "patient_id2",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "c58acff5-248b-49c9-b18d-69e4a84a08d9"
     },
     {
       "name": "group_id",
       "description": "",
       "title": "Group ID",
       "type": "text",
-      "value": "Cervical-patients"
+      "value": "Example-group"
+    },
+    {
+      "name": "group_subjects",
+      "description": "",
+      "title": "Number of subjects in the provided Group",
+      "type": "text",
+      "value": "2"
     },
     {
       "name": "practitioner_id",
@@ -72,6 +86,13 @@
       "title": "FHIR resource types",
       "type": "text",
       "value": "Encounter"
+    },
+    {
+      "name": "measure_url_list",
+      "description": "Example: http://example.org/Measure/A|1.0.0,http://example.org/Measure/B|1.2.3",
+      "title": "Measures (comma-separated URLs with versions)",
+      "type": "text",
+      "value": "https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth|0.6.000,https://madie.cms.gov/Measure/CMS1017FHIRHHFI|0.2.000"
     }
   ]
 }

--- a/lib/deqm_test_kit/evaluate.rb
+++ b/lib/deqm_test_kit/evaluate.rb
@@ -340,10 +340,6 @@ module DEQMTestKit
               valueString: selected_measure_id
             },
             {
-              name: 'subject',
-              valueString: 'Group/test-group-2-subjects'
-            },
-            {
               name: 'subjectGroup',
               resource: {
                 resourceType: 'Group',
@@ -421,10 +417,6 @@ module DEQMTestKit
               valueString: selected_measure_id
             },
             {
-              name: 'subject',
-              valueString: 'Group/test-group-2-subjects'
-            },
-            {
               name: 'subjectGroup',
               resource: {
                 resourceType: 'Group',
@@ -500,10 +492,6 @@ module DEQMTestKit
               valueString: selected_measure_id
             },
             {
-              name: 'subject',
-              valueString: 'Group/test-group'
-            },
-            {
               name: 'subjectGroup',
               resource: {
                 resourceType: 'Group',
@@ -573,10 +561,6 @@ module DEQMTestKit
             {
               name: 'measureId',
               valueString: selected_measure_id
-            },
-            {
-              name: 'subject',
-              valueString: 'Group/test-group'
             },
             {
               name: 'subjectGroup',

--- a/lib/deqm_test_kit/submit_data_v3.rb
+++ b/lib/deqm_test_kit/submit_data_v3.rb
@@ -41,7 +41,20 @@ module DEQMTestKit
     id 'submit_data_v3'
     title 'submit-data-v3'
     description 'Ensure fhir server can receive data via the $submit-data operation'
-    custom_headers = { 'X-Provenance': '{"resourceType": "Provenance", "agent": ["test-agent"]}' }
+    provenance = {
+      resourceType: 'Provenance',
+      agent: [
+        {
+          who: {
+            reference: 'Practitioner/test-agent',
+            type: 'Practitioner'
+          }
+        }
+      ]
+    }
+    custom_headers = {
+      'X-Provenance' => provenance.to_json
+    }
     measure_options = JSON.parse(File.read('./lib/fixtures/measureRadioButton.json'))
     measure_id_args = {
       type: 'radio',

--- a/lib/deqm_test_kit/submit_data_v5.rb
+++ b/lib/deqm_test_kit/submit_data_v5.rb
@@ -96,7 +96,20 @@ module DEQMTestKit
     id 'submit_data_v5'
     title '$submit-data-v5'
     description 'Ensure fhir server can receive data via the $submit-data operation'
-    custom_headers = { 'X-Provenance': '{"resourceType": "Provenance", "agent": ["test-agent"]}' }
+    provenance = {
+      resourceType: 'Provenance',
+      agent: [
+        {
+          who: {
+            reference: 'Practitioner/test-agent',
+            type: 'Practitioner'
+          }
+        }
+      ]
+    }
+    custom_headers = {
+      'X-Provenance' => provenance.to_json
+    }
 
     input :measure_url_list,
           title: 'Measures (comma-separated URLs with versions)',

--- a/lib/fixtures/measureAvailabilityRadioButton.json
+++ b/lib/fixtures/measureAvailabilityRadioButton.json
@@ -1,72 +1,44 @@
 {
   "list_options": [
     {
-      "label": "Colorectal Cancer ScreeningFHIR",
-      "value": "ColorectalCancerScreeningsFHIR|0.0.003"
-    },
-    {
-      "label": "Discharged on Antithrombotic Therapy FHIR",
-      "value": "DischargedonAntithromboticTherapyFHIR|2.0.012"
-    },
-    {
-      "label": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease FHIR",
-      "value": "FHIR347|0.1.021"
-    },
-    {
-      "label": "Cervical Cancer ScreeningFHIR",
-      "value": "CervicalCancerScreeningFHIR|0.0.005"
-    },
-    {
-      "label": "Breast Cancer ScreeningFHIR",
-      "value": "BreastCancerScreeningsFHIR|0.0.002"
-    },
-    {
-      "label": "Colorectal Cancer ScreeningFHIR",
-      "value": "ColorectalCancerScreeningsFHIR|0.0.003"
-    },
-    {
-      "label": "CMS130 FHIR Colorectal Cancer Screening",
-      "value": "CMS130FHIRColorectalCancerScreening"
-    },
-    {
-      "label": "CMS816 FHIR HHHypo",
-      "value": "CMS816FHIRHHHypo"
-    },
-    {
-      "label": "CMS506 FHIR Safe Use of Opioids",
-      "value": "CMS506FHIRSafeUseofOpioids"
-    },
-    {
-      "label": "CMS2 FHIR PCS Depression Screen And Follow Up",
-      "value": "CMS2FHIRPCSDepressionScreenAndFollowUp"
-    },
-    {
-      "label": "CMS122 FHIR Diabetes Assess Greater Than 9 Percent",
-      "value": "CMS122FHIRDiabetesAssessGreaterThan9Percent"
-    },
-    {
-      "label": "CMS124 FHIR Cervical Cancer Screening",
-      "value": "CMS124FHIRCervicalCancerScreening"
-    },
-    {
-      "label": "CMS125 FHIR Breast Cancer Screening",
-      "value": "CMS125FHIRBreastCancerScreening"
-    },
-    {
-      "label": "CMS165 FHIR Controlliing High Blood Pressure",
-      "value": "CMS165FHIRControllingHighBloodPressure"
+      "label": "CMS0334FHIRPCCesareanBirth",
+      "value": "CMS0334FHIRPCCesareanBirth"
     },
     {
       "label": "CMS1017FHIRHHFI",
       "value": "CMS1017FHIRHHFI"
     },
     {
+      "label": "CMS1056CTClinicalFHIR",
+      "value": "CMS1056CTClinicalFHIR"
+    },
+    {
+      "label": "CMS1074FHIRCTIQR",
+      "value": "CMS1074FHIRCTIQR"
+    },
+    {
+      "label": "CMS108FHIRVTEProphylaxis",
+      "value": "CMS108FHIRVTEProphylaxis"
+    },
+    {
+      "label": "CMS117FHIRChildhoodImmunizationStatus",
+      "value": "CMS117FHIRChildhoodImmunizationStatus"
+    },
+    {
       "label": "CMS1218FHIRHHRF",
       "value": "CMS1218FHIRHHRF"
     },
     {
-      "label": "NHSN Glycemic Control Hypoglycemia Initial Population",
-      "value": "NHSNGlycemicControlHypoglycemiaInitialPopulation"
+      "label": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
+      "value": "CMS122FHIRDiabetesAssessGreaterThan9Percent"
+    },
+    {
+      "label": "CMS1244FHIRECATHOQR",
+      "value": "CMS1244FHIRECATHOQR"
+    },
+    {
+      "label": "CMS124FHIRCervicalCancerScreening",
+      "value": "CMS124FHIRCervicalCancerScreening"
     }
   ]
 }

--- a/lib/fixtures/measureCheckBoxes.json
+++ b/lib/fixtures/measureCheckBoxes.json
@@ -1,68 +1,44 @@
 {
   "list_options": [
     {
-      "label": "Colorectal Cancer ScreeningFHIR",
-      "value": "ColorectalCancerScreeningsFHIR"
-    },
-    {
-      "label": "Discharged on Antithrombotic Therapy FHIR",
-      "value": "DischargedonAntithromboticTherapyFHIR"
-    },
-    {
-      "label": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease FHIR",
-      "value": "FHIR347"
-    },
-    {
-      "label": "Cervical Cancer ScreeningFHIR",
-      "value": "CervicalCancerScreeningFHIR"
-    },
-    {
-      "label": "Breast Cancer ScreeningFHIR",
-      "value": "BreastCancerScreeningsFHIR"
-    },
-    {
-      "label": "CMS130 FHIR Colorectal Cancer Screening",
-      "value": "CMS130FHIRColorectalCancerScreening"
-    },
-    {
-      "label": "CMS816 FHIR HHHypo",
-      "value": "CMS816FHIRHHHypo"
-    },
-    {
-      "label": "CMS506 FHIR Safe Use of Opioids",
-      "value": "CMS506FHIRSafeUseofOpioids"
-    },
-    {
-      "label": "CMS2 FHIR PCS Depression Screen And Follow Up",
-      "value": "CMS2FHIRPCSDepressionScreenAndFollowUp"
-    },
-    {
-      "label": "CMS122 FHIR Diabetes Assess Greater Than 9 Percent",
-      "value": "CMS122FHIRDiabetesAssessGreaterThan9Percent"
-    },
-    {
-      "label": "CMS124 FHIR Cervical Cancer Screening",
-      "value": "CMS124FHIRCervicalCancerScreening"
-    },
-    {
-      "label": "CMS125 FHIR Breast Cancer Screening",
-      "value": "CMS125FHIRBreastCancerScreening"
-    },
-    {
-      "label": "CMS165 FHIR Controlliing High Blood Pressure",
-      "value": "CMS165FHIRControllingHighBloodPressure"
+      "label": "CMS0334FHIRPCCesareanBirth",
+      "value": "CMS0334FHIRPCCesareanBirth"
     },
     {
       "label": "CMS1017FHIRHHFI",
       "value": "CMS1017FHIRHHFI"
     },
     {
+      "label": "CMS1056CTClinicalFHIR",
+      "value": "CMS1056CTClinicalFHIR"
+    },
+    {
+      "label": "CMS1074FHIRCTIQR",
+      "value": "CMS1074FHIRCTIQR"
+    },
+    {
+      "label": "CMS108FHIRVTEProphylaxis",
+      "value": "CMS108FHIRVTEProphylaxis"
+    },
+    {
+      "label": "CMS117FHIRChildhoodImmunizationStatus",
+      "value": "CMS117FHIRChildhoodImmunizationStatus"
+    },
+    {
       "label": "CMS1218FHIRHHRF",
       "value": "CMS1218FHIRHHRF"
     },
     {
-      "label": "NHSN Glycemic Control Hypoglycemia Initial Population",
-      "value": "NHSNGlycemicControlHypoglycemiaInitialPopulation"
+      "label": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
+      "value": "CMS122FHIRDiabetesAssessGreaterThan9Percent"
+    },
+    {
+      "label": "CMS1244FHIRECATHOQR",
+      "value": "CMS1244FHIRECATHOQR"
+    },
+    {
+      "label": "CMS124FHIRCervicalCancerScreening",
+      "value": "CMS124FHIRCervicalCancerScreening"
     }
   ]
 }

--- a/lib/fixtures/measureRadioButton.json
+++ b/lib/fixtures/measureRadioButton.json
@@ -1,68 +1,44 @@
 {
   "list_options": [
     {
-      "label": "Colorectal Cancer ScreeningFHIR",
-      "value": "ColorectalCancerScreeningsFHIR"
-    },
-    {
-      "label": "Discharged on Antithrombotic Therapy FHIR",
-      "value": "DischargedonAntithromboticTherapyFHIR"
-    },
-    {
-      "label": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease FHIR",
-      "value": "FHIR347"
-    },
-    {
-      "label": "Cervical Cancer ScreeningFHIR",
-      "value": "CervicalCancerScreeningFHIR"
-    },
-    {
-      "label": "Breast Cancer ScreeningFHIR",
-      "value": "BreastCancerScreeningsFHIR"
-    },
-    {
-      "label": "CMS130 FHIR Colorectal Cancer Screening",
-      "value": "CMS130FHIRColorectalCancerScreening"
-    },
-    {
-      "label": "CMS816 FHIR HHHypo",
-      "value": "CMS816FHIRHHHypo"
-    },
-    {
-      "label": "CMS506 FHIR Safe Use of Opioids",
-      "value": "CMS506FHIRSafeUseofOpioids"
-    },
-    {
-      "label": "CMS2 FHIR PCS Depression Screen And Follow Up",
-      "value": "CMS2FHIRPCSDepressionScreenAndFollowUp"
-    },
-    {
-      "label": "CMS122 FHIR Diabetes Assess Greater Than 9 Percent",
-      "value": "CMS122FHIRDiabetesAssessGreaterThan9Percent"
-    },
-    {
-      "label": "CMS124 FHIR Cervical Cancer Screening",
-      "value": "CMS124FHIRCervicalCancerScreening"
-    },
-    {
-      "label": "CMS125 FHIR Breast Cancer Screening",
-      "value": "CMS125FHIRBreastCancerScreening"
-    },
-    {
-      "label": "CMS165 FHIR Controlliing High Blood Pressure",
-      "value": "CMS165FHIRControllingHighBloodPressure"
+      "label": "CMS0334FHIRPCCesareanBirth",
+      "value": "CMS0334FHIRPCCesareanBirth"
     },
     {
       "label": "CMS1017FHIRHHFI",
       "value": "CMS1017FHIRHHFI"
     },
     {
+      "label": "CMS1056CTClinicalFHIR",
+      "value": "CMS1056CTClinicalFHIR"
+    },
+    {
+      "label": "CMS1074FHIRCTIQR",
+      "value": "CMS1074FHIRCTIQR"
+    },
+    {
+      "label": "CMS108FHIRVTEProphylaxis",
+      "value": "CMS108FHIRVTEProphylaxis"
+    },
+    {
+      "label": "CMS117FHIRChildhoodImmunizationStatus",
+      "value": "CMS117FHIRChildhoodImmunizationStatus"
+    },
+    {
       "label": "CMS1218FHIRHHRF",
       "value": "CMS1218FHIRHHRF"
     },
     {
-      "label": "NHSN Glycemic Control Hypoglycemia Initial Population",
-      "value": "NHSNGlycemicControlHypoglycemiaInitialPopulation"
+      "label": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
+      "value": "CMS122FHIRDiabetesAssessGreaterThan9Percent"
+    },
+    {
+      "label": "CMS1244FHIRECATHOQR",
+      "value": "CMS1244FHIRECATHOQR"
+    },
+    {
+      "label": "CMS124FHIRCervicalCancerScreening",
+      "value": "CMS124FHIRCervicalCancerScreening"
     },
     {
       "label": "Other",


### PR DESCRIPTION
# Summary
This PR updates some small issues for existing tests, with a focus on the STU5 suite.

## New behavior
- There were unexpectedly failing evaluate and submit-data tests that now pass. All STU 5 tests should pass with the exception of 3 evaluate tests.

## Code changes
- Evaluate: Removed subject parameter from all evaluation requests which use subjectGroup. Subject and subjectGroup should be exclusive. See https://github.com/projecttacoma/deqm-test-server/pull/171 for more information.
- Submit-data: Makes Provenance header contain a proper agent object instead of a string. Provenance with a simple string agent does not seem compatible with our code that creates audit events in deqm-test-server, nor is it a valid construction for a provenance resource. This must have been ignored in the past but a string agent is now rightfully causing an error for an invalid provenance (perhaps due to node update?). 

# Testing guidance
- `bundle exec rubocop`
- `bundle exec rspec` 
- Run the deqm-test-server on (I ran using docker using `docker compose up --build` on the branch [here](https://github.com/projecttacoma/deqm-test-server/pull/182))
- Run test kit locally with `ASYNC_JOBS=false bundle exec puma` (or alternatively use the dockerized test kit and adjust default settings accordingly)
- Run the all tests on the DEQM STU5 test suite with the DEQM Test Server Local preset. Make sure that the deqm-test-server is loaded with bundles (I loaded with `npm run upload-bundles-test` using local npm scripts using db port 27018 with a `'27018:27017'` port mapping in my docker-compose file. You will also need to create the EXM124-patients Group- send a PUT request to `http://localhost:3000/4_0_1/Group/EXM124-patients` with Content-Type as application/json+fhir in the headers and the following JSON body:

```
{
	"resourceType": "Group",
	"id": "EXM124-patients",
	"type": "person",
	"actual": "true",
	"member": [
		{
			"entity": {
				"reference": "Patient/denom-EXM124"
			}
		},
		{
			"entity": {
				"reference": "Patient/numer-EXM124"
			}
		}
	]
}
```
- 3 tests (5.7, 5.9, and 5.11) should still fail with deqm-test-server as reportType=subject with a subjectGroup is not yet implemented on the server. Everything else should pass.
