### PR TITLE
STU 1 Suite and initial collect-data success tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'debug'
   gem 'factory_bot', '~> 6.1'
   gem 'rspec', '~> 3.10'
+  gem 'sidekiq', '~> 7.2.4'
   gem 'webmock', '~> 3.11'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     deqm_test_kit (0.0.1)
       inferno_core (~> 1.1.2)
+      sidekiq (~> 7.2.4)
 
 GEM
   remote: https://rubygems.org/
@@ -388,6 +389,7 @@ DEPENDENCIES
   rspec (~> 3.10)
   rubocop (~> 1.18)
   rubocop-rspec (~> 2.4)
+  sidekiq (~> 7.2.4)
   webmock (~> 3.11)
 
 BUNDLED WITH

--- a/deqm_test_kit.gemspec
+++ b/deqm_test_kit.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/projecttacoma/deqm-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_dependency 'inferno_core', '~> 1.1.2'
+  spec.add_dependency 'sidekiq', '~> 7.2.4'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.3.6')
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/projecttacoma/deqm-test-kit'

--- a/lib/deqm_test_kit.rb
+++ b/lib/deqm_test_kit.rb
@@ -2,3 +2,4 @@
 
 require_relative 'deqm_test_kit/v3.0.0/deqm_test_suite'
 require_relative 'deqm_test_kit/v5.0.0/deqm_test_suite'
+require_relative 'deqm_test_kit/v1.0.0/deqm_test_suite'

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -42,7 +42,16 @@ module DEQMTestKit
 
         parameters.parameter.each do |param|
           assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+          validate_bundles_contain_measure_report(param.resource)
         end
+      end
+
+      def validate_bundles_contain_measure_report(bundle)
+        assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
+        assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
+
+        measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
+        assert measure_reports.any?, 'Expected at least one MeasureReport in Bundle'
       end
 
       def collect_data_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -18,9 +18,8 @@ module DEQMTestKit
         assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
         assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
 
-        parameters.parameter.each do |param|
-          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
-        end
+        # Check that first parameter is a bundle, checking all of them will cause the test to timeout
+        assert parameters.parameter[0].resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
       end
 
       def collect_data_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength
@@ -135,7 +134,8 @@ module DEQMTestKit
         assert result.resource.is_a?(FHIR::Parameters), "Expected
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
-        # validate that the FHIR Parameters resource contains at least one FHIR Bundle
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters)
       end
     end
 
@@ -165,6 +165,9 @@ module DEQMTestKit
         assert_response_status(200)
         assert result.resource.is_a?(FHIR::Parameters), "Expected
         resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters)
       end
     end
 
@@ -196,7 +199,8 @@ module DEQMTestKit
         assert result.resource.is_a?(FHIR::Parameters), "Expected
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
-        # validate that the FHIR Parameters resource contains at least one FHIR Bundle
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters)
       end
     end
   end

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module DEQMTestKit
+  # tests for $collect-data (DEQM UV v1.0.0)
+  # rubocop:disable Metrics/ClassLength
+  class CollectDataV1 < Inferno::TestGroup
+    # module for shared code for $collect-data assertions and requests
+    module CollectDataHelpers
+      def selected_measure_url(custom_url:, url:)
+        return custom_url.strip if url == 'Other' && custom_url&.strip&.length&.positive? # rubocop:disable Style/SafeNavigationChainLength
+
+        url
+      end
+
+      def validate_parameters_contains_bundles(parameters)
+        assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
+        assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
+
+        parameters.parameter.each do |param|
+          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+        end
+      end
+
+      def collect_data_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength
+        {
+          resourceType: 'Parameters',
+          parameter: [
+            *measure_urls.map do |url|
+              {
+                name: 'measureUrl',
+                valueCanonical: url
+              }
+            end,
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+      end
+    end
+
+    id :collect_data_v1
+    title '$collect-data'
+    description 'Ensure FHIR server can perform the $collect-data operation'
+
+    fhir_client do
+      url :url
+      headers origin: url.to_s,
+              referrer: url.to_s,
+              'Content-Type': 'application/fhir+json'
+    end
+
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureUrlRadioButton.json'))
+    measure_url_args = {
+      type: 'radio',
+      optional: false,
+      default: 'https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth',
+      options: measure_options,
+      title: 'Measure URL'
+    }
+    additional_measure_args = {
+      type: 'radio',
+      optional: false,
+      options: measure_options,
+      title: 'Measure URL for additional Measure'
+    }
+    custom_measure_url_args = {
+      type: 'text',
+      optional: true,
+      title: 'Custom Measure URL',
+      description: 'If you selected "Other" above, enter it here.'
+    }
+    custom_additional_measure_url_args = {
+      type: 'text',
+      optional: true,
+      title: 'Custom Additional Measure URL',
+      description: 'If you selected "Other" for the additional Measure URL, enter it here.'
+    }
+
+    test do
+      include CollectDataHelpers
+
+      title 'GET Measure/$collect-data with one measureUrl, periodStart, periodEnd'
+      id 'collect-data-one-measure-get'
+      description %(GET Measure/$collect-data with one measureUrl, periodStart, periodEnd returns 200 and
+      FHIR Parameters resource that contains at least one FHIR Bundle.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: period_end
+        )
+
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get,
+                                                          body: FHIR::Parameters.new(body))
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+      end
+    end
+
+    test do
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd'
+      id 'collect-data-one-measure-post'
+      description %(POST Measure/$collect-data with one measureUrl, periodStart, periodEnd returns 200 and
+      FHIR Parameters resource that contains at least one FHIR Bundle.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: period_end
+        )
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        # validate that the FHIR Parameters resource contains at least one FHIR Bundle
+      end
+    end
+
+    test do
+      include CollectDataHelpers
+
+      title 'GET Measure/$collect-data with one measureUrl, periodStart, periodEnd'
+      id 'collect-data-two-measure-get'
+      description %(GET Measure/$collect-data with two measureUrls, periodStart, periodEnd returns 200 and
+      FHIR Parameters resource that contains at least one FHIR Bundle.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = collect_data_body(measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url),
+                                                selected_measure_url(custom_url: custom_additional_measure_url,
+                                                                     url: additional_measure_url)],
+                                 period_start: period_start, period_end: period_end)
+
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get,
+                                                          body: FHIR::Parameters.new(body))
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+      end
+    end
+
+    test do
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd'
+      id 'collect-data-two-measure-post'
+      description %(POST Measure/$collect-data with two measureUrls, periodStart, periodEnd returns 200 and
+      FHIR Parameters resource that contains at least one FHIR Bundle.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url),
+                         selected_measure_url(custom_url: custom_additional_measure_url,
+                                              url: additional_measure_url)], period_start: period_start,
+          period_end: period_end
+        )
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        # validate that the FHIR Parameters resource contains at least one FHIR Bundle
+      end
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -8,10 +8,32 @@ module DEQMTestKit
   class CollectDataV1 < Inferno::TestGroup
     # module for shared code for $collect-data assertions and requests
     module CollectDataHelpers
-      def selected_measure_url(custom_url:, url:)
-        return custom_url.strip if url == 'Other' && custom_url&.strip&.length&.positive? # rubocop:disable Style/SafeNavigationChainLength
+      def selected_measure_url(custom_url:, url:, input_title: 'Measure URL',
+                               custom_input_title: 'Custom Measure URL')
+        return url unless url == 'Other'
 
-        url
+        custom_url = custom_url.to_s.strip
+
+        assert custom_url.length.positive?,
+               "#{custom_input_title} is required when \"#{input_title}\" is \"Other\"."
+
+        custom_url
+      end
+
+      def selected_additional_measure_url(custom_url:, url:)
+        selected_measure_url(
+          custom_url:,
+          url:,
+          input_title: 'Measure URL for additional Measure',
+          custom_input_title: 'Custom Additional Measure URL'
+        )
+      end
+
+      def selected_measure_urls
+        [
+          selected_measure_url(custom_url: custom_measure_url, url: measure_url),
+          selected_additional_measure_url(custom_url: custom_additional_measure_url, url: additional_measure_url)
+        ]
       end
 
       def validate_parameters_contains_bundles(parameters)
@@ -158,10 +180,11 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = collect_data_body(measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url),
-                                                selected_measure_url(custom_url: custom_additional_measure_url,
-                                                                     url: additional_measure_url)],
-                                 period_start: period_start, period_end: period_end)
+        body = collect_data_body(
+          measure_urls: selected_measure_urls,
+          period_start: period_start,
+          period_end: period_end
+        )
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get,
                                                           body: FHIR::Parameters.new(body))
@@ -191,9 +214,8 @@ module DEQMTestKit
 
       run do
         body = collect_data_body(
-          measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url),
-                         selected_measure_url(custom_url: custom_additional_measure_url,
-                                              url: additional_measure_url)], period_start: period_start,
+          measure_urls: selected_measure_urls,
+          period_start: period_start,
           period_end: period_end
         )
 

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -107,6 +107,9 @@ module DEQMTestKit
         assert_response_status(200)
         assert result.resource.is_a?(FHIR::Parameters), "Expected
         resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters)
       end
     end
 

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -40,8 +40,9 @@ module DEQMTestKit
         assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
         assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
 
-        # Check that first parameter is a bundle, checking all of them will cause the test to timeout
-        assert parameters.parameter[0].resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+        parameters.parameter.each do |param|
+          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+        end
       end
 
       def collect_data_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -36,22 +36,23 @@ module DEQMTestKit
         ]
       end
 
-      def validate_parameters_contains_bundles(parameters)
+      def validate_parameters_contains_bundles(parameters, measure_count)
         assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
         assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
 
         parameters.parameter.each do |param|
           assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
-          validate_bundles_contain_measure_report(param.resource)
+          validate_bundles_contain_measure_report(param.resource, measure_count)
         end
       end
 
-      def validate_bundles_contain_measure_report(bundle)
+      def validate_bundles_contain_measure_report(bundle, measure_count)
         assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
         assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
 
         measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
-        assert measure_reports.any?, 'Expected at least one MeasureReport in Bundle'
+        assert measure_reports.length == measure_count,
+               "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
       end
 
       def collect_data_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength
@@ -141,7 +142,7 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        validate_parameters_contains_bundles(parameters)
+        validate_parameters_contains_bundles(parameters, 1)
       end
     end
 
@@ -170,7 +171,7 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        validate_parameters_contains_bundles(parameters)
+        validate_parameters_contains_bundles(parameters, 1)
       end
     end
 
@@ -203,7 +204,7 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        validate_parameters_contains_bundles(parameters)
+        validate_parameters_contains_bundles(parameters, 2)
       end
     end
 
@@ -235,7 +236,7 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        validate_parameters_contains_bundles(parameters)
+        validate_parameters_contains_bundles(parameters, 2)
       end
     end
   end

--- a/lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb
+++ b/lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative '../collect_data_v1'
+
+module DEQMTestKit
+  # Test suite for DEQM Universal Realm Version 1.0.0
+  module DEQMV100
+    class DEQMTestKit < Inferno::TestSuite # rubocop:disable Style/Documentation
+      id :deqm_v100
+      title 'DEQM Universal Realm v1.0.0 Measure Operations Test Suite'
+      description 'A set of tests for v1.0.0 DEQM Universal Realm\'s operations and resources'
+
+      input :url
+
+      fhir_client do
+        url :url
+        headers origin: url.to_s,
+                referrer: url.to_s,
+                'Content-Type': 'application/fhir+json'
+      end
+
+      group do
+        id :capability_statement
+        title 'Capability Statement'
+        description 'Verify that the server has a Capability Statement'
+
+        test do
+          id :capability_statement_read
+          title 'Read CapabilityStatement'
+          description 'Read CapabilityStatement from /metadata endpoint'
+
+          run do
+            fhir_get_capability_statement
+
+            assert_response_status(200)
+            assert_resource_type(:capability_statement)
+          end
+        end
+      end
+
+      group from: :collect_data_v1
+    end
+  end
+end

--- a/lib/fixtures/measureUrlRadioButton.json
+++ b/lib/fixtures/measureUrlRadioButton.json
@@ -1,0 +1,48 @@
+{
+  "list_options": [
+    {
+      "label": "CMS0334FHIRPCCesareanBirth",
+      "value": "https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth"
+    },
+    {
+      "label": "CMS1017FHIRHHFI",
+      "value": "https://madie.cms.gov/Measure/CMS1017FHIRHHFI"
+    },
+    {
+      "label": "CMS1056CTClinicalFHIR",
+      "value": "https://madie.cms.gov/Measure/CMS1056CTClinicalFHIR"
+    },
+    {
+      "label": "CMS1074FHIRCTIQR",
+      "value": "https://madie.cms.gov/Measure/CMS1074FHIRCTIQR"
+    },
+    {
+      "label": "CMS108FHIRVTEProphylaxis",
+      "value": "https://madie.cms.gov/Measure/CMS108FHIRVTEProphylaxis"
+    },
+    {
+      "label": "CMS117FHIRChildhoodImmunizationStatus",
+      "value": "https://madie.cms.gov/Measure/CMS117FHIRChildhoodImmunizationStatus"
+    },
+    {
+      "label": "CMS1218FHIRHHRF",
+      "value": "https://madie.cms.gov/Measure/CMS1218FHIRHHRF"
+    },
+    {
+      "label": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
+      "value": "https://madie.cms.gov/Measure/CMS122FHIRDiabetesAssessGreaterThan9Percent"
+    },
+    {
+      "label": "CMS1244FHIRECATHOQR",
+      "value": "https://madie.cms.gov/Measure/CMS1244FHIRECATHOQR"
+    },
+    {
+      "label": "CMS124FHIRCervicalCancerScreening",
+      "value": "https://madie.cms.gov/Measure/CMS124FHIRCervicalCancerScreening"
+    },
+    {
+      "label": "Other",
+      "value": "Other"
+    }
+  ]
+}

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
     end)
   end
 
+  def create_parameters_request(measure_urls:, period_start:, period_end:)
+    parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
+    parameters << { name: 'periodStart', valueDate: period_start }
+    parameters << { name: 'periodEnd', valueDate: period_end }
+
+    {
+      resourceType: 'Parameters',
+      parameter: parameters
+    }
+  end
+
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
@@ -79,13 +90,14 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
     let(:period_end) { '2019-12-31' }
 
     it 'passes with correct FHIR Parameters resource returned' do
+      parameters_request = create_parameters_request(measure_urls: [measure_url], period_start:, period_end:)
       parameters_response = create_parameters_response(measure_urls: [measure_url])
 
       stub_request(
         :post,
         "#{url}/Measure/$collect-data"
       ).with(
-        body: '{"resourceType":"Parameters","parameter":[{"name":"measureUrl","valueCanonical":"http://example.com/Measure/measure-EXM130"},{"name":"periodStart","valueDate":"2019-01-01"},{"name":"periodEnd","valueDate":"2019-12-31"}]}', # rubocop:disable Layout/LineLength
+        body: parameters_request.to_json,
         headers: {
           'Content-Type' => 'application/fhir+json',
           'Origin' => 'http://example.com/fhir',
@@ -140,12 +152,17 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
 
     it 'passes with correct FHIR Parameters resource returned' do
       parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+      parameters_request = create_parameters_request(
+        measure_urls: [measure_url, additional_measure_url],
+        period_start:,
+        period_end:
+      )
 
       stub_request(
         :post,
         "#{url}/Measure/$collect-data"
       ).with(
-        body: '{"resourceType":"Parameters","parameter":[{"name":"measureUrl","valueCanonical":"http://example.com/Measure/measure-EXM130"},{"name":"measureUrl","valueCanonical":"http://example.com/Measure/measure-EXM124"},{"name":"periodStart","valueDate":"2019-01-01"},{"name":"periodEnd","valueDate":"2019-12-31"}]}', # rubocop:disable Layout/LineLength
+        body: parameters_request.to_json,
         headers: {
           'Content-Type' => 'application/fhir+json',
           'Origin' => 'http://example.com/fhir',

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -21,16 +21,13 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       )
     end
 
-    bundles = measure_reports.map do |mr|
-      FHIR::Bundle.new(type: 'transaction', entry: [{ resource: mr }])
-    end
+    bundle = FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
 
-    FHIR::Parameters.new(parameter: bundles.map do |bundle|
+    FHIR::Parameters.new(parameter:
       {
         name: 'return',
         resource: bundle
-      }
-    end)
+      })
   end
 
   def create_parameters_request(measure_urls:, period_start:, period_end:)

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
+INVALID_START_DATE = 'INVALID_START_DATE'
+
+RSpec.describe DEQMTestKit::CollectDataV1 do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_v100') }
+  let(:group) { suite.groups[1] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  # Helper method to create a valid Parameters resource
+  def create_parameters_response(measure_urls:) # rubocop:disable Metrics/MethodLength
+    measure_reports = measure_urls.map do |url|
+      FHIR::MeasureReport.new(
+        status: 'complete', type: 'data-collection',
+        measure: url,
+        period: { start: '2019-01-01', end: '2019-12-31' }
+      )
+    end
+
+    bundles = measure_reports.map do |mr|
+      FHIR::Bundle.new(type: 'transaction', entry: [{ resource: mr }])
+    end
+
+    FHIR::Parameters.new(parameter: bundles.map do |bundle|
+      {
+        name: 'return',
+        resource: bundle
+      }
+    end)
+  end
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name:, value:, type: 'text')
+    end
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  describe 'GET Measure/$collect-data with one measureUrl and required params' do
+    let(:test) { test_by_id(group, 'collect-data-one-measure-get') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          periodStart: period_start,
+          periodEnd: period_end
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data with one measureUrl and required params' do
+    let(:test) { test_by_id(group, 'collect-data-one-measure-post') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: '{"resourceType":"Parameters","parameter":[{"name":"measureUrl","valueCanonical":"http://example.com/Measure/measure-EXM130"},{"name":"periodStart","valueDate":"2019-01-01"},{"name":"periodEnd","valueDate":"2019-12-31"}]}', # rubocop:disable Layout/LineLength
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$collect-data with two measureUrls and required params' do
+    let(:test) { test_by_id(group, 'collect-data-two-measure-get') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+      query = URI.encode_www_form([
+                                    ['measureUrl', measure_url],
+                                    ['measureUrl', additional_measure_url],
+                                    ['periodStart', period_start],
+                                    ['periodEnd', period_end]
+                                  ])
+
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: query,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data with two measureUrls and required params' do
+    let(:test) { test_by_id(group, 'collect-data-two-measure-post') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: '{"resourceType":"Parameters","parameter":[{"name":"measureUrl","valueCanonical":"http://example.com/Measure/measure-EXM130"},{"name":"measureUrl","valueCanonical":"http://example.com/Measure/measure-EXM124"},{"name":"periodStart","valueDate":"2019-01-01"},{"name":"periodEnd","valueDate":"2019-12-31"}]}', # rubocop:disable Layout/LineLength
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This PR adds a Universal Realm STU 1 Test Suite to the DEQM Test Kit that includes a basic capability statement test as well as 4 success tests for the $collect-data operation.

## New behavior
The 4 $collect-data success tests are as follows:
1. Tests GET Measure/$collect-data with one measureUrl, periodStart, periodEnd returns 200 status and FHIR Parameters resource where Parameters.parameter contains FHIR Bundle resources.
2. Tests POST Measure/$collect-data with one measureUrl, periodStart, periodEnd returns 200 status and FHIR Parameters resource where Parameters.parameter contains FHIR Bundle resources.
3. Tests GET Measure/$collect-data with two measureUrls, periodStart, periodEnd returns 200 status and FHIR Parameters resource where Parameters.parameter contains FHIR Bundle resources.
4. Tests POST Measure/$collect-data with two measureUrls, periodStart, periodEnd returns 200 status and FHIR Parameters resource where Parameters.parameter contains FHIR Bundle resources.

## Code changes
- `Gemfile`, `Gemfile.lock`, `deqm_test_kit.gemspec` - I was having trouble with `bundle install` with sidekiq, so I added it as a dependency
- `lib/deqm_test_kit.rb` - Added Universal Realm STU 1 (https://hl7.org/fhir/uv/deqm/2026May/en/) Test Suite
- `lib/deqm-test-kit/collect_data_v1.rb` - test group for $collect-data operation tests for the Universal Realm STU 1 suite. Currently includes 4 success tests.
- `lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb` - Universal Realm STU 1 Test Suite
- `measureUrlRadioButton.json` - Radio buttons that contain the `measureUrl` as the value
- `spec/deqm_test_kit/v1.0.0/collect_data_spec.rb` - simple spec tests collect-data test group.

# Testing guidance
- `bundle exec rubocop`
- `bundle exec rspec`
- Spin up this test kit with `ASYNC_JOBS=false bundle exec puma` (there are other ways to do this, but this makes it easy since it won't spin up the deqm-test-server and you won't have port conflicts)
- Spin up `bulk-export-server` with `npm run start` (this server contains the $collect-data endpoint that is best for testing this test group at the moment)
- `bulk-export-server` should be loaded with ecqm-content-qicore-2025 bundles. Note that bulk-export-server's $collect-data will have some valueset issues for certain Measures. Known measures that will result in passing tests are: CMS1017FHIRHHFI, CMS1056CTClinicalFHIR, CMS1074FHIRCTIQR, CMS117FHIRChildhoodImmunizationStatus, CMS1218FHIRHHRF, CMS122FHIRDiabetesAssessGreaterThan9Percent, and CMS124FHIRCervicalCancerScreening.
- Test the Universal Realm STU 1 test suite with url `http://localhost:3000` (or wherever your bulk-export-server is running)