### PR TITLE
Collect data fail tests

### DIFF
--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -239,6 +239,39 @@ module DEQMTestKit
         validate_parameters_contains_bundles(parameters, 2)
       end
     end
+
+    # GET Measure/$collect-data with measureUrl and periodStart in request parameters returns 400 and
+    # FHIR Operation Outcome when periodEnd was missing.
+    test do
+      title 'GET Measure/$collect-data with one measureUrl, periodStart'
+      id 'collect-data-missing-period-end-fail'
+      description %(GET Measure/$collect-data with one measureUrl and periodStart returns 400 and
+      FHIR OperationOutcome when periodEnd was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+
+      run do
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'measureUrl',
+              valueCanonical: measure_url
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -243,8 +243,10 @@ module DEQMTestKit
     # GET Measure/$collect-data with measureUrl and periodStart in request parameters returns 400 and
     # FHIR Operation Outcome when periodEnd was missing.
     test do
+      include CollectDataHelpers
+
       title 'GET Measure/$collect-data with one measureUrl, periodStart'
-      id 'collect-data-missing-period-end-fail'
+      id 'collect-data-missing-period-end-get-fail'
       description %(GET Measure/$collect-data with one measureUrl and periodStart returns 400 and
       FHIR OperationOutcome when periodEnd was missing.)
 
@@ -253,21 +255,170 @@ module DEQMTestKit
       input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
 
       run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodStart', valueDate: period_start }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$collect-data with measureUrl and periodStart in request body returns 400 and
+    # FHIR Operation Outcome when periodEnd was missing.
+    test do
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data with one measureUrl, periodStart'
+      id 'collect-data-missing-period-end-post-fail'
+      description %(POST Measure/$collect-data with one measureUrl and periodStart returns 400 and
+      FHIR OperationOutcome when periodEnd was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodStart', valueDate: period_start }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # GET Measure/$collect-data with measureUrl and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when periodStart was missing.
+    test do
+      include CollectDataHelpers
+
+      title 'GET Measure/$collect-data with one measureUrl, periodEnd'
+      id 'collect-data-missing-period-start-get-fail'
+      description %(GET Measure/$collect-data with one measureUrl and periodEnd returns 400 and
+      FHIR OperationOutcome when periodStart was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodEnd', valueDate: period_end }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$collect-data with measureUrl and periodEnd in request body returns 400 and
+    # FHIR Operation Outcome when periodStart was missing.
+    test do
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data with one measureUrl, periodEnd'
+      id 'collect-data-missing-period-start-post-fail'
+      description %(POST Measure/$collect-data with one measureUrl and periodEnd returns 400 and
+      FHIR OperationOutcome when periodStart was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodEnd', valueDate: period_end }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # GET Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when measureUrl was missing.
+    test do
+      title 'GET Measure/$collect-data with one periodStart, periodEnd'
+      id 'collect-data-missing-measure-url-get-fail'
+      description %(GET Measure/$collect-data with one periodStart and periodEnd returns 400 and
+      FHIR OperationOutcome when measureUrl was missing.)
+
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
         body = {
           resourceType: 'Parameters',
           parameter: [
             {
-              name: 'measureUrl',
-              valueCanonical: measure_url
-            },
-            {
               name: 'periodStart',
               valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
             }
           ]
         }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when measureUrl was missing.
+    test do
+      title 'POST Measure/$collect-data with one periodStart, periodEnd'
+      id 'collect-data-missing-measure-url-post-fail'
+      description %(POST Measure/$collect-data with one periodStart and periodEnd returns 400 and
+      FHIR OperationOutcome when measureUrl was missing.)
+
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)
         assert result.resource.is_a?(FHIR::OperationOutcome)
       end

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -255,11 +255,15 @@ module DEQMTestKit
       input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
 
       run do
-        body = collect_data_body(
-          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
-                                              url: measure_url)], period_start: period_start, period_end: '2026-12-31'
-        )
-        body[:parameter].delete_if { |param| param[:name] == 'periodEnd' }
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodStart', valueDate: period_start }
+            # periodEnd intentionally omitted
+          ]
+        }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
         assert_response_status(400)
@@ -282,11 +286,15 @@ module DEQMTestKit
       input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
 
       run do
-        body = collect_data_body(
-          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
-                                              url: measure_url)], period_start: period_start, period_end: '2026-12-31'
-        )
-        body[:parameter].delete_if { |param| param[:name] == 'periodEnd' }
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodStart', valueDate: period_start }
+            # periodEnd intentionally omitted
+          ]
+        }
 
         result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)
@@ -309,11 +317,15 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = collect_data_body(
-          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
-                                              url: measure_url)], period_start: '2026-01-01', period_end: period_end
-        )
-        body[:parameter].delete_if { |param| param[:name] == 'periodStart' }
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodEnd', valueDate: period_end }
+            # periodStart intentionally omitted
+          ]
+        }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
         assert_response_status(400)
@@ -336,11 +348,15 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = collect_data_body(
-          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
-                                              url: measure_url)], period_start: '2026-01-01', period_end: period_end
-        )
-        body[:parameter].delete_if { |param| param[:name] == 'periodStart' }
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodEnd', valueDate: period_end }
+            # periodStart intentionally omitted
+          ]
+        }
 
         result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)
@@ -351,8 +367,6 @@ module DEQMTestKit
     # GET Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and
     # FHIR Operation Outcome when measureUrl was missing.
     test do
-      include CollectDataHelpers
-
       title 'GET Measure/$collect-data missing measureUrl returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-measure-url-get-fail'
       description %(GET Measure/$collect-data with one periodStart and periodEnd returns 400 and
@@ -362,11 +376,20 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = collect_data_body(
-          measure_urls: ['https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth'], period_start: period_start,
-          period_end: period_end
-        )
-        body[:parameter].delete_if { |param| param[:name] == 'measureUrl' }
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+            # measureUrl intentionally omitted
+          ]
+        }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
         assert_response_status(400)
@@ -377,8 +400,6 @@ module DEQMTestKit
     # POST Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and
     # FHIR Operation Outcome when measureUrl was missing.
     test do
-      include CollectDataHelpers
-
       title 'POST Measure/$collect-data missing measureUrl returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-measure-url-post-fail'
       description %(POST Measure/$collect-data with one periodStart and periodEnd returns 400 and
@@ -388,11 +409,20 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = collect_data_body(
-          measure_urls: ['https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth'], period_start: period_start,
-          period_end: period_end
-        )
-        body[:parameter].delete_if { |param| param[:name] == 'measureUrl' }
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+            # measureUrl intentionally omitted
+          ]
+        }
 
         result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -178,7 +178,7 @@ module DEQMTestKit
     test do
       include CollectDataHelpers
 
-      title 'GET Measure/$collect-data with one measureUrl, periodStart, periodEnd'
+      title 'GET Measure/$collect-data with two measureUrls, periodStart, periodEnd'
       id 'collect-data-two-measure-get'
       description %(GET Measure/$collect-data with two measureUrls, periodStart, periodEnd returns 200 and
       FHIR Parameters resource that contains at least one FHIR Bundle.)
@@ -211,7 +211,7 @@ module DEQMTestKit
     test do
       include CollectDataHelpers
 
-      title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd'
+      title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd'
       id 'collect-data-two-measure-post'
       description %(POST Measure/$collect-data with two measureUrls, periodStart, periodEnd returns 200 and
       FHIR Parameters resource that contains at least one FHIR Bundle.)
@@ -245,7 +245,7 @@ module DEQMTestKit
     test do
       include CollectDataHelpers
 
-      title 'GET Measure/$collect-data with one measureUrl, periodStart'
+      title 'GET Measure/$collect-data missing periodEnd returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-end-get-fail'
       description %(GET Measure/$collect-data with one measureUrl and periodStart returns 400 and
       FHIR OperationOutcome when periodEnd was missing.)
@@ -255,14 +255,11 @@ module DEQMTestKit
       input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
 
       run do
-        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
-        body = {
-          resourceType: 'Parameters',
-          parameter: [
-            { name: 'measureUrl', valueCanonical: selected_url },
-            { name: 'periodStart', valueDate: period_start }
-          ]
-        }
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: '2026-12-31'
+        )
+        body[:parameter].delete_if { |param| param[:name] == 'periodEnd' }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
         assert_response_status(400)
@@ -275,7 +272,7 @@ module DEQMTestKit
     test do
       include CollectDataHelpers
 
-      title 'POST Measure/$collect-data with one measureUrl, periodStart'
+      title 'POST Measure/$collect-data missing periodEnd returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-end-post-fail'
       description %(POST Measure/$collect-data with one measureUrl and periodStart returns 400 and
       FHIR OperationOutcome when periodEnd was missing.)
@@ -285,14 +282,11 @@ module DEQMTestKit
       input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
 
       run do
-        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
-        body = {
-          resourceType: 'Parameters',
-          parameter: [
-            { name: 'measureUrl', valueCanonical: selected_url },
-            { name: 'periodStart', valueDate: period_start }
-          ]
-        }
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: '2026-12-31'
+        )
+        body[:parameter].delete_if { |param| param[:name] == 'periodEnd' }
 
         result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)
@@ -305,7 +299,7 @@ module DEQMTestKit
     test do
       include CollectDataHelpers
 
-      title 'GET Measure/$collect-data with one measureUrl, periodEnd'
+      title 'GET Measure/$collect-data missing periodStart returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-start-get-fail'
       description %(GET Measure/$collect-data with one measureUrl and periodEnd returns 400 and
       FHIR OperationOutcome when periodStart was missing.)
@@ -315,14 +309,11 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
-        body = {
-          resourceType: 'Parameters',
-          parameter: [
-            { name: 'measureUrl', valueCanonical: selected_url },
-            { name: 'periodEnd', valueDate: period_end }
-          ]
-        }
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: '2026-01-01', period_end: period_end
+        )
+        body[:parameter].delete_if { |param| param[:name] == 'periodStart' }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
         assert_response_status(400)
@@ -335,7 +326,7 @@ module DEQMTestKit
     test do
       include CollectDataHelpers
 
-      title 'POST Measure/$collect-data with one measureUrl, periodEnd'
+      title 'POST Measure/$collect-data missing periodStart returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-start-post-fail'
       description %(POST Measure/$collect-data with one measureUrl and periodEnd returns 400 and
       FHIR OperationOutcome when periodStart was missing.)
@@ -345,14 +336,11 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
-        body = {
-          resourceType: 'Parameters',
-          parameter: [
-            { name: 'measureUrl', valueCanonical: selected_url },
-            { name: 'periodEnd', valueDate: period_end }
-          ]
-        }
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: '2026-01-01', period_end: period_end
+        )
+        body[:parameter].delete_if { |param| param[:name] == 'periodStart' }
 
         result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)
@@ -363,7 +351,9 @@ module DEQMTestKit
     # GET Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and
     # FHIR Operation Outcome when measureUrl was missing.
     test do
-      title 'GET Measure/$collect-data with one periodStart, periodEnd'
+      include CollectDataHelpers
+
+      title 'GET Measure/$collect-data missing measureUrl returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-measure-url-get-fail'
       description %(GET Measure/$collect-data with one periodStart and periodEnd returns 400 and
       FHIR OperationOutcome when measureUrl was missing.)
@@ -372,19 +362,11 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = {
-          resourceType: 'Parameters',
-          parameter: [
-            {
-              name: 'periodStart',
-              valueDate: period_start
-            },
-            {
-              name: 'periodEnd',
-              valueDate: period_end
-            }
-          ]
-        }
+        body = collect_data_body(
+          measure_urls: ['https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth'], period_start: period_start,
+          period_end: period_end
+        )
+        body[:parameter].delete_if { |param| param[:name] == 'measureUrl' }
 
         result = fhir_operation('/Measure/$collect-data', operation_method: :get, body: FHIR::Parameters.new(body))
         assert_response_status(400)
@@ -395,7 +377,9 @@ module DEQMTestKit
     # POST Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and
     # FHIR Operation Outcome when measureUrl was missing.
     test do
-      title 'POST Measure/$collect-data with one periodStart, periodEnd'
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data missing measureUrl returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-measure-url-post-fail'
       description %(POST Measure/$collect-data with one periodStart and periodEnd returns 400 and
       FHIR OperationOutcome when measureUrl was missing.)
@@ -404,19 +388,11 @@ module DEQMTestKit
       input :period_end, title: 'Measurement Period End', default: '2026-12-31'
 
       run do
-        body = {
-          resourceType: 'Parameters',
-          parameter: [
-            {
-              name: 'periodStart',
-              valueDate: period_start
-            },
-            {
-              name: 'periodEnd',
-              valueDate: period_end
-            }
-          ]
-        }
+        body = collect_data_body(
+          measure_urls: ['https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth'], period_start: period_start,
+          period_end: period_end
+        )
+        body[:parameter].delete_if { |param| param[:name] == 'measureUrl' }
 
         result = fhir_operation('/Measure/$collect-data', body: body)
         assert_response_status(400)

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -171,4 +171,181 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       expect(result.result).to eq('pass')
     end
   end
+
+  describe 'GET Measure/$collect-data missing periodEnd' do
+    let(:test) { test_by_id(group, 'collect-data-missing-period-end-get-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          periodStart: period_start
+          # periodEnd intentionally omitted
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data missing periodEnd' do
+    let(:test) { test_by_id(group, 'collect-data-missing-period-end-post-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'measureUrl', valueCanonical: measure_url },
+          { name: 'periodStart', valueDate: period_start }
+          # periodEnd intentionally omitted
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$collect-data missing periodStart' do
+    let(:test) { test_by_id(group, 'collect-data-missing-period-start-get-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          periodEnd: period_end
+          # periodStart intentionally omitted
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data missing periodStart' do
+    let(:test) { test_by_id(group, 'collect-data-missing-period-start-post-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'measureUrl', valueCanonical: measure_url },
+          { name: 'periodEnd', valueDate: period_end }
+          # periodStart intentionally omitted
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$collect-data missing measureUrl' do
+    let(:test) { test_by_id(group, 'collect-data-missing-measure-url-get-fail') }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: {
+          periodStart: period_start,
+          periodEnd: period_end
+          # measureUrl intentionally omitted
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data missing measureUrl' do
+    let(:test) { test_by_id(group, 'collect-data-missing-measure-url-post-fail') }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: period_start },
+          { name: 'periodEnd', valueDate: period_end }
+          # measureUrl intentionally omitted
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
 end


### PR DESCRIPTION
# Summary
This PR adds 6 fail tests for the $collect-data operation in the Universal Realm STU 1 Test Suite.
## New behavior
The 6 $collect-data failure tests are as follows:
- GET Measure/$collect-data with measureUrl and periodStart in request parameters returns 400 and FHIR Operation Outcome when periodEnd was missing.
- POST Measure/$collect-data with measureUrl and periodStart in request body returns 400 and FHIR Operation Outcome when periodEnd was missing.
- GET Measure/$collect-data with measureUrl and periodEnd in request parameters returns 400 and FHIR Operation Outcome when periodStart was missing.
- POST Measure/$collect-data with measureUrl and periodEnd in request body returns 400 and FHIR Operation Outcome when periodStart was missing.
- GET Measure/$collect-data with periodStart and periodEnd in request parameters returns 400 and FHIR Operation Outcome when measureUrl was missing.
- POST Measure/$collect-data with periodStart and periodEnd in request body returns 400 and FHIR Operation Outcome when measureUrl was missing.
## Code changes
lib/deqm-test-kit/collect_data_v1.rb - Added 6 failure tests.
# Testing guidance
- `bundle exec rubocop`
- `bundle exec rspec`
- Spin up this test kit with `ASYNC_JOBS=false bundle exec puma` 
- Spin up `bulk-export-server` with `npm run start` 
- `bulk-export-server` should be loaded with ecqm-content-qicore-2025 bundles. Note that bulk-export-server's $collect-data will have some valueset issues for certain Measures. Known measures that will result in passing tests are: CMS1017FHIRHHFI, CMS1056CTClinicalFHIR, CMS1074FHIRCTIQR, CMS117FHIRChildhoodImmunizationStatus, CMS1218FHIRHHRF, CMS122FHIRDiabetesAssessGreaterThan9Percent, and CMS124FHIRCervicalCancerScreening.
- Test the Universal Realm STU 1 test suite with url `http://localhost:3000` (or wherever your bulk-export-server is running)
