### PR TITLE
STU 1 evaluate tests

### DIFF
--- a/lib/deqm_test_kit/evaluate_v1.rb
+++ b/lib/deqm_test_kit/evaluate_v1.rb
@@ -122,7 +122,7 @@ module DEQMTestKit
 
       title 'GET Measure/$evaluate with one measureUrl, required params (default reportType=summary)'
       id 'evaluate-one-measure-summary-get'
-      description %(Measure/$evaluate with one measureUrl and without reportType (defaults to reportType=summary)
+      description %(GET Measure/$evaluate with one measureUrl and without reportType (defaults to reportType=summary)
       returns 200 and FHIR Parameters resource.)
 
       input :measure_url, **measure_url_args
@@ -153,7 +153,7 @@ module DEQMTestKit
 
       title 'POST Measure/$evaluate with one measureUrl, required params (default reportType=summary)'
       id 'evaluate-one-measure-summary-post'
-      description %(Measure/$evaluate with one measureUrl and without reportType (defaults to reportType=summary)
+      description %(POST Measure/$evaluate with one measureUrl and without reportType (defaults to reportType=summary)
       returns 200 and FHIR Parameters resource.)
 
       input :measure_url, **measure_url_args
@@ -183,7 +183,7 @@ module DEQMTestKit
       # This doesn't seem to be possible with Inferno DSL fhir_operation
       title 'GET Measure/$evaluate with two measureUrls, required params (default reportType=summary)'
       id 'evaluate-two-measure-summary-get'
-      description %(Measure/$evaluate with two measureUrls and without reportType (defaults to reportType=summary)
+      description %(GET Measure/$evaluate with two measureUrls and without reportType (defaults to reportType=summary)
       returns 200 and FHIR Parameters resource.)
 
       input :measure_url, **measure_url_args
@@ -217,7 +217,7 @@ module DEQMTestKit
 
       title 'POST Measure/$evaluate with two measureUrls, required params (default reportType=summary)'
       id 'evaluate-two-measure-summary-post'
-      description %(Measure/$evaluate with two measureUrls and without reportType (defaults to reportType=summary)
+      description %(POST Measure/$evaluate with two measureUrls and without reportType (defaults to reportType=summary)
       returns 200 and FHIR Parameters resource.)
 
       input :measure_url, **measure_url_args

--- a/lib/deqm_test_kit/evaluate_v1.rb
+++ b/lib/deqm_test_kit/evaluate_v1.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module DEQMTestKit
+  # tests for $evaluate (DEQM UV v1.0.0)
+  class EvaluateV1 < Inferno::TestGroup # rubocop:disable Metrics/ClassLength
+    # module for shared code for $evaluate assertions and requests
+    module MeasureEvaluationHelpers
+      def selected_measure_url(custom_url:, url:, input_title: 'Measure URL',
+                               custom_input_title: 'Custom Measure URL')
+        return url unless url == 'Other'
+
+        custom_url = custom_url.to_s.strip
+
+        assert custom_url.length.positive?,
+               "#{custom_input_title} is required when \"#{input_title}\" is \"Other\"."
+
+        custom_url
+      end
+
+      def selected_additional_measure_url(custom_url:, url:)
+        selected_measure_url(
+          custom_url:,
+          url:,
+          input_title: 'Measure URL for additional Measure',
+          custom_input_title: 'Custom Additional Measure URL'
+        )
+      end
+
+      def selected_measure_urls
+        [
+          selected_measure_url(custom_url: custom_measure_url, url: measure_url),
+          selected_additional_measure_url(custom_url: custom_additional_measure_url, url: additional_measure_url)
+        ]
+      end
+
+      def evaluate_request_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength
+        {
+          resourceType: 'Parameters',
+          parameter: [
+            *measure_urls.map do |url|
+              {
+                name: 'measureUrl',
+                valueCanonical: url
+              }
+            end,
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+      end
+
+      def validate_parameters_contains_bundles(parameters, measure_count)
+        assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
+        assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
+
+        parameters.parameter.each do |param|
+          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+          validate_bundles_contain_measure_report(param.resource, measure_count)
+        end
+      end
+
+      def validate_bundles_contain_measure_report(bundle, measure_count)
+        assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
+        assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
+
+        measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
+        assert measure_reports.length == measure_count,
+               "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
+      end
+    end
+
+    id :evaluate_v1
+    title '$evaluate'
+    description 'Ensure FHIR server can calculate a Measure using $evaluate operation (DEQM UV v1.0.0)'
+
+    fhir_client do
+      url :url
+      headers origin: url.to_s,
+              referrer: url.to_s,
+              'Content-Type': 'application/fhir+json'
+    end
+
+    include MeasureEvaluationHelpers
+
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureUrlRadioButton.json'))
+    measure_url_args = {
+      type: 'radio',
+      optional: false,
+      default: 'https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth',
+      options: measure_options,
+      title: 'Measure URL'
+    }
+    additional_measure_args = {
+      type: 'radio',
+      optional: false,
+      options: measure_options,
+      title: 'Measure URL for additional Measure'
+    }
+    custom_measure_url_args = {
+      type: 'text',
+      optional: true,
+      title: 'Custom Measure URL',
+      description: 'If you selected "Other" above or want to provide a custom Measure URL, enter it here.'
+    }
+    custom_additional_measure_url_args = {
+      type: 'text',
+      optional: true,
+      title: 'Custom Additional Measure URL',
+      description: 'If you selected "Other" for the additional Measure URL, enter it here.'
+    }
+
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'GET Measure/$evaluate with one measureUrl, required params (default reportType=summary)'
+      id 'evaluate-one-measure-summary-get'
+      description %(Measure/$evaluate with one measureUrl and without reportType (defaults to reportType=summary)
+      returns 200 and FHIR Parameters resource.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = evaluate_request_body(
+          period_start: period_start,
+          period_end: period_end,
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url)]
+        )
+
+        result = fhir_operation('/Measure/$evaluate', body: FHIR::Parameters.new(body), operation_method: :get)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+
+        validate_parameters_contains_bundles(parameters, 1)
+      end
+    end
+
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'POST Measure/$evaluate with one measureUrl, required params (default reportType=summary)'
+      id 'evaluate-one-measure-summary-post'
+      description %(Measure/$evaluate with one measureUrl and without reportType (defaults to reportType=summary)
+      returns 200 and FHIR Parameters resource.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = evaluate_request_body(
+          period_start: period_start,
+          period_end: period_end,
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url)]
+        )
+        result = fhir_operation('/Measure/$evaluate', body: body)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters, 1)
+      end
+    end
+
+    test do
+      include MeasureEvaluationHelpers
+
+      # This doesn't seem to be possible with Inferno DSL fhir_operation
+      title 'GET Measure/$evaluate with two measureUrls, required params (default reportType=summary)'
+      id 'evaluate-two-measure-summary-get'
+      description %(Measure/$evaluate with two measureUrls and without reportType (defaults to reportType=summary)
+      returns 200 and FHIR Parameters resource.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = evaluate_request_body(
+          period_start: period_start,
+          period_end: period_end,
+          measure_urls: selected_measure_urls
+        )
+
+        result = fhir_operation('/Measure/$evaluate', operation_method: :get,
+                                                      body: FHIR::Parameters.new(body))
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters, 2)
+      end
+    end
+
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'POST Measure/$evaluate with two measureUrls, required params (default reportType=summary)'
+      id 'evaluate-two-measure-summary-post'
+      description %(Measure/$evaluate with two measureUrls and without reportType (defaults to reportType=summary)
+      returns 200 and FHIR Parameters resource.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = evaluate_request_body(
+          period_start: period_start,
+          period_end: period_end,
+          measure_urls: selected_measure_urls
+        )
+
+        result = fhir_operation('/Measure/$evaluate', body: body)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters, 2)
+      end
+    end
+  end
+end

--- a/lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb
+++ b/lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../evaluate_v1'
 require_relative '../collect_data_v1'
 
 module DEQMTestKit
@@ -38,6 +39,7 @@ module DEQMTestKit
         end
       end
 
+      group from: :evaluate_v1
       group from: :collect_data_v1
     end
   end

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -5,7 +5,7 @@ INVALID_START_DATE = 'INVALID_START_DATE'
 
 RSpec.describe DEQMTestKit::CollectDataV1 do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_v100') }
-  let(:group) { suite.groups[1] }
+  let(:group) { suite.groups[2] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }

--- a/spec/deqm_test_kit/v1.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/evaluate_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
+INVALID_START_DATE = 'INVALID_START_DATE'
+
+RSpec.describe DEQMTestKit::EvaluateV1 do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_v100') }
+  let(:group) { suite.groups[1] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  # Helper method to create a valid Parameters resource
+  def create_parameters_response(measure_urls:) # rubocop:disable Metrics/MethodLength
+    measure_reports = measure_urls.map do |url|
+      FHIR::MeasureReport.new(
+        status: 'complete', type: 'summary',
+        measure: url,
+        period: { start: '2019-01-01', end: '2019-12-31' }
+      )
+    end
+
+    bundle = FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
+
+    FHIR::Parameters.new(parameter:
+      {
+        name: 'return',
+        resource: bundle
+      })
+  end
+
+  def create_parameters_request(measure_urls:, period_start:, period_end:)
+    parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
+    parameters << { name: 'periodStart', valueDate: period_start }
+    parameters << { name: 'periodEnd', valueDate: period_end }
+
+    {
+      resourceType: 'Parameters',
+      parameter: parameters
+    }
+  end
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name:, value:, type: 'text')
+    end
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  describe 'GET Measure/$evaluate with one measureUrl and required params' do
+    let(:test) { test_by_id(group, 'evaluate-one-measure-summary-get') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :get,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          periodStart: period_start,
+          periodEnd: period_end
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$evaluate with one measureUrl and required params' do
+    let(:test) { test_by_id(group, 'evaluate-one-measure-summary-post') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_request = create_parameters_request(measure_urls: [measure_url], period_start:, period_end:)
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$evaluate with two measureUrls and required params' do
+    let(:test) { test_by_id(group, 'evaluate-two-measure-summary-get') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+      query = URI.encode_www_form([
+                                    ['measureUrl', measure_url],
+                                    ['measureUrl', additional_measure_url],
+                                    ['periodStart', period_start],
+                                    ['periodEnd', period_end]
+                                  ])
+
+      stub_request(
+        :get,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        query: query,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$evaluate with two measureUrls and required params' do
+    let(:test) { test_by_id(group, 'evaluate-two-measure-summary-post') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+      parameters_request = create_parameters_request(
+        measure_urls: [measure_url, additional_measure_url],
+        period_start:,
+        period_end:
+      )
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This PR creates a test group for the $evaluate operation in the DEQM Universal Realm STU 1 Test Suite with the four reportType=summary success tests:
- GET Measure/$evaluate with one measureUrl
- POST Measure/$evaluate with one measureUrl
- GET Measure/$evaluate with two measureUrls
- POST Measure/$evaluate with two measureUrls

## New behavior
The DEQM Universal Realm STU 1 suite now has a test group with 4 tests for the $evaluate operation.

## Code changes
- `lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb` - adds new group
- `lib/deqm_test_kit/v1.0.0/evaluate_v1.rb` - new test group
- `spec/deqm_test_kit/v1.0.0/collect_data_spec.rb` - changes index to reflect new order of test groups
- `spec/deqm_test_kit/v1.0.0/evaluate_spec.rb` - associated spec tests

# Testing guidance
In `deqm-test-kit`:
- `bundle exec rspec`
- `bundle exec rubocop`
- `ASYNC_JOBS=false bundle exec puma` 

In `deqm-test-server`:
- `git checkout update-evaluate`
- `npm run db:reset`
- `npm run upload-bundles`
- `npm run start`

In the test kit UI inputs:
- Measure URL "Other" radio button
- Custom Measure URL: http://ecqi.healthit.gov/ecqms/Measure/ColorectalCancerScreeningsFHIR
- url: http://localhost:3000/4_0_1
- Measure URL for additional Measure "Other" radio button
- Custom Additional Measure URL: http://ecqi.healthit.gov/ecqms/Measure/BreastCancerScreeningsFHIR

NOTE: I realize at this point there is a good amount of repeated code. My thinking is that we hold off on doing any refactoring while we focus on building out tests for the Connectathon. Refactoring/consolidation can come later.