### PR TITLE
Stu collect data subject

### DIFF
--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -240,6 +240,143 @@ module DEQMTestKit
       end
     end
 
+    test do
+      include CollectDataHelpers
+
+      title 'GET Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subject=Patient/patientId'
+      id 'collect-data-one-measure-get-subject-patient'
+      description %(GET Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subject=Patient/patientId
+      returns 200 and FHIR Parameters resource that contains exactly one FHIR Bundle that contains one MeasureReport)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :patient_id, title: 'Patient ID'
+
+      run do
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: period_end
+        ).concat({ name: 'subject', valueString: patient_id })
+
+        fhir_operation('/Measure/$collect-data', operation_method: :get,
+                                                 body: FHIR::Parameters.new(body))
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        # this below will have to be adjusted
+        validate_parameters_contains_bundles(parameters, 1)
+      end
+    end
+
+    test do
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subject=Patient/patientId'
+      id 'collect-data-one-measure-post-subject-patient'
+      description %(POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and
+      subject=Patient/patientId returns 200 and FHIR Parameters resource that contains exactly one FHIR Bundle that
+      contains one MeasureReport)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :patient_id, title: 'Patient ID'
+
+      run do
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: period_end
+        ).concat({ name: 'subject', valueString: patient_id })
+
+        fhir_operation('/Measure/$collect-data',
+                       body: FHIR::Parameters.new(body))
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        # this below will have to be adjusted
+        validate_parameters_contains_bundles(parameters, 1)
+      end
+    end
+
+    test do
+      include CollectDataHelpers
+
+      title 'GET Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subject=Patient/patientId'
+      id 'collect-data-two-measure-get-subject-patient'
+      description %(GET Measure/$collect-data with two measureUrls, periodStart, periodEnd, and
+      subject=Patient/patientId returns 200 and FHIR Parameters resource that contains exactly one FHIR Bundle that
+      contains two MeasureReports)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :patient_id, title: 'Patient ID'
+
+      run do
+        body = collect_data_body(
+          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end
+        ).concat({ name: 'subject', valueString: patient_id })
+
+        fhir_operation('/Measure/$collect-data', operation_method: :get,
+                                                 body: FHIR::Parameters.new(body))
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        # this below will have to be adjusted
+        validate_parameters_contains_bundles(parameters, 2)
+      end
+    end
+
+    test do
+      include CollectDataHelpers
+
+      title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subject=Patient/patientId'
+      id 'collect-data-two-measure-post-subject-patient'
+      description %(POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and
+      subject=Patient/patientId returns 200 and FHIR Parameters resource that contains exactly one FHIR Bundle that
+      contains two MeasureReports)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :patient_id, title: 'Patient ID'
+
+      run do
+        body = collect_data_body(
+          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end
+        ).concat({ name: 'subject', valueString: patient_id })
+
+        fhir_operation('/Measure/$collect-data',
+                       body: FHIR::Parameters.new(body))
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        # this below will have to be adjusted
+        validate_parameters_contains_bundles(parameters, 2)
+      end
+    end
+
     # GET Measure/$collect-data with measureUrl and periodStart in request parameters returns 400 and
     # FHIR Operation Outcome when periodEnd was missing.
     test do

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -48,7 +48,7 @@ module DEQMTestKit
 
       def validate_number_of_bundles(parameters, bundle_count)
         assert parameters.parameter.length == bundle_count,
-               "Expected #{bundle_count} Bundle(s), got #{parameters.length}"
+               "Expected #{bundle_count} Bundle(s), got #{parameters.parameter.length}"
       end
 
       def validate_bundles_contain_measure_report(bundle, measure_count)
@@ -60,25 +60,34 @@ module DEQMTestKit
                "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
       end
 
-      def collect_data_body(period_start:, period_end:, measure_urls:) # rubocop:disable Metrics/MethodLength
+      def collect_data_body(period_start:, period_end:, measure_urls:, patient_id: nil) # rubocop:disable Metrics/MethodLength
+        parameters = measure_urls.map do |url|
+          {
+            name: 'measureUrl',
+            valueCanonical: url
+          }
+        end
+
+        if patient_id
+          parameters << {
+            name: 'subject',
+            valueString: "Patient/#{patient_id}"
+          }
+        end
+
+        parameters << {
+          name: 'periodStart',
+          valueDate: period_start
+        }
+
+        parameters << {
+          name: 'periodEnd',
+          valueDate: period_end
+        }
+
         {
           resourceType: 'Parameters',
-          parameter: [
-            *measure_urls.map do |url|
-              {
-                name: 'measureUrl',
-                valueCanonical: url
-              }
-            end,
-            {
-              name: 'periodStart',
-              valueDate: period_start
-            },
-            {
-              name: 'periodEnd',
-              valueDate: period_end
-            }
-          ]
+          parameter: parameters
         }
       end
     end
@@ -262,11 +271,12 @@ module DEQMTestKit
       run do
         body = collect_data_body(
           measure_urls: [selected_measure_url(custom_url: custom_measure_url,
-                                              url: measure_url)], period_start: period_start, period_end: period_end
-        ).concat({ name: 'subject', valueString: patient_id })
+                                              url: measure_url)], period_start: period_start, period_end: period_end,
+          patient_id: patient_id
+        )
 
-        fhir_operation('/Measure/$collect-data', operation_method: :get,
-                                                 body: FHIR::Parameters.new(body))
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get,
+                                                          body: FHIR::Parameters.new(body))
 
         assert_response_status(200)
         assert result.resource.is_a?(FHIR::Parameters), "Expected
@@ -297,11 +307,11 @@ module DEQMTestKit
       run do
         body = collect_data_body(
           measure_urls: [selected_measure_url(custom_url: custom_measure_url,
-                                              url: measure_url)], period_start: period_start, period_end: period_end
-        ).concat({ name: 'subject', valueString: patient_id })
+                                              url: measure_url)], period_start: period_start, period_end: period_end,
+          patient_id: patient_id
+        )
 
-        fhir_operation('/Measure/$collect-data',
-                       body: FHIR::Parameters.new(body))
+        result = fhir_operation('/Measure/$collect-data', body: body)
 
         assert_response_status(200)
         assert result.resource.is_a?(FHIR::Parameters), "Expected
@@ -333,11 +343,12 @@ module DEQMTestKit
 
       run do
         body = collect_data_body(
-          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end
-        ).concat({ name: 'subject', valueString: patient_id })
+          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end,
+          patient_id: patient_id
+        )
 
-        fhir_operation('/Measure/$collect-data', operation_method: :get,
-                                                 body: FHIR::Parameters.new(body))
+        result = fhir_operation('/Measure/$collect-data', operation_method: :get,
+                                                          body: FHIR::Parameters.new(body))
 
         assert_response_status(200)
         assert result.resource.is_a?(FHIR::Parameters), "Expected
@@ -369,11 +380,11 @@ module DEQMTestKit
 
       run do
         body = collect_data_body(
-          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end
-        ).concat({ name: 'subject', valueString: patient_id })
+          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end,
+          patient_id: patient_id
+        )
 
-        fhir_operation('/Measure/$collect-data',
-                       body: FHIR::Parameters.new(body))
+        result = fhir_operation('/Measure/$collect-data', body: body)
 
         assert_response_status(200)
         assert result.resource.is_a?(FHIR::Parameters), "Expected

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -46,6 +46,11 @@ module DEQMTestKit
         end
       end
 
+      def validate_number_of_bundles(parameters, bundle_count)
+        assert parameters.parameter.length == bundle_count,
+               "Expected #{bundle_count} Bundle(s), got #{parameters.length}"
+      end
+
       def validate_bundles_contain_measure_report(bundle, measure_count)
         assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
         assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
@@ -268,7 +273,8 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        # this below will have to be adjusted
+
+        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 1)
       end
     end
@@ -302,12 +308,13 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        # this below will have to be adjusted
+
+        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 1)
       end
     end
 
-    test do
+    test do # rubocop:disable Metrics/BlockLength
       include CollectDataHelpers
 
       title 'GET Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subject=Patient/patientId'
@@ -337,12 +344,13 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        # this below will have to be adjusted
+
+        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 2)
       end
     end
 
-    test do
+    test do # rubocop:disable Metrics/BlockLength
       include CollectDataHelpers
 
       title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subject=Patient/patientId'
@@ -372,7 +380,8 @@ module DEQMTestKit
         resource to be a Parameters resource, but got #{result.resource&.class}"
 
         parameters = result.resource
-        # this below will have to be adjusted
+
+        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 2)
       end
     end

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -284,8 +284,8 @@ module DEQMTestKit
 
         parameters = result.resource
 
-        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 1)
+        validate_number_of_bundles(parameters, 1)
       end
     end
 
@@ -319,8 +319,8 @@ module DEQMTestKit
 
         parameters = result.resource
 
-        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 1)
+        validate_number_of_bundles(parameters, 1)
       end
     end
 
@@ -356,8 +356,8 @@ module DEQMTestKit
 
         parameters = result.resource
 
-        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 2)
+        validate_number_of_bundles(parameters, 1)
       end
     end
 
@@ -392,8 +392,8 @@ module DEQMTestKit
 
         parameters = result.resource
 
-        validate_number_of_bundles(parameters, 1)
         validate_parameters_contains_bundles(parameters, 2)
+        validate_number_of_bundles(parameters, 1)
       end
     end
 

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -234,6 +234,71 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
     end
   end
 
+  describe 'GET Measure/$collect-data with two measureUrls and subject=Patient/patientId' do
+    let(:test) { test_by_id(group, 'collect-data-two-measure-get-subject-patient') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_id) { 'numer-EXM130' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+      query = URI.encode_www_form([
+                                    ['measureUrl', measure_url],
+                                    ['measureUrl', additional_measure_url],
+                                    ['periodStart', period_start],
+                                    ['periodEnd', period_end],
+                                    ['subject', "Patient/#{patient_id}"]
+                                  ])
+
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: query,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_id:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data with two measureUrls and subject=Patient/patientId' do
+    let(:test) { test_by_id(group, 'collect-data-two-measure-post-subject-patient') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_id) { 'numer-EXM130' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_request = create_parameters_request(measure_urls: [measure_url, additional_measure_url], period_start:,
+                                                     period_end:, patient_id:)
+      parameters_response = create_parameters_response(measure_urls: [measure_url, additional_measure_url])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_id:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
   describe 'GET Measure/$collect-data missing periodEnd' do
     let(:test) { test_by_id(group, 'collect-data-missing-period-end-get-fail') }
     let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       })
   end
 
-  def create_parameters_request(measure_urls:, period_start:, period_end:)
+  def create_parameters_request(measure_urls:, period_start:, period_end:, patient_id: nil)
     parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
+    parameters << { name: 'subject', valueString: "Patient/#{patient_id}" } if patient_id
     parameters << { name: 'periodStart', valueDate: period_start }
     parameters << { name: 'periodEnd', valueDate: period_end }
 
@@ -168,6 +169,67 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       ).to_return(status: 200, body: parameters_response.to_json, headers: {})
 
       result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$collect-data with one measureUrl and subject=Patient/patientId' do
+    let(:test) { test_by_id(group, 'collect-data-one-measure-get-subject-patient') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_id) { 'numer-EXM130' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :get,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          subject: "Patient/#{patient_id}",
+          periodStart: period_start,
+          periodEnd: period_end
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:, patient_id:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data with one measureUrl and subject=Patient/patientId' do
+    let(:test) { test_by_id(group, 'collect-data-one-measure-post-subject-patient') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_id) { 'numer-EXM130' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_request = create_parameters_request(measure_urls: [measure_url], period_start:, period_end:,
+                                                     patient_id:)
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:, patient_id:)
       expect(result.result).to eq('pass')
     end
   end


### PR DESCRIPTION
# Summary
This PR adds tests for $collect-data requests with the `subject` parameter included with a Patient reference.

## New behavior
Four new tests added to the DEQM UV STU1 Test Suite for the $collect-data test suite.

## Code changes
- `lib/deqm_test_kit/collect_data_v1.rb` - add method `validate_number_of_bundles` to check that the right number of bundles are returned, update `collect_data_body` method to include optional `subject` parameter for some tests, 4 new subject parameter tests
- `spec/deqm_test_kit/v1.0.0/collect_data_spec.rb` - new associated spec tests

# Testing guidance
In deqm-test-kit:
- `bundle exec rspec`
- `bundle exec rubocop`
- `ASYNC_JOBS=false bundle exec puma`
- Inputs to use:
    - Measure URL: CMS1017FHIRHHFI
    - url: http://localhost:3001
    - Measure URL for additional Measure: `CMS1047FHIRCTIQR`
    - Patient ID: f6dafa7e-15a9-4fec-baea-59d43201caf8

In bulk-export-server (at the same time):
- `npm run start`