### PR TITLE
add fail tests for stu1 evaluate

### DIFF
--- a/lib/deqm_test_kit/evaluate_v1.rb
+++ b/lib/deqm_test_kit/evaluate_v1.rb
@@ -243,5 +243,295 @@ module DEQMTestKit
         validate_parameters_contains_bundles(parameters, 2)
       end
     end
+
+    # GET Measure/$evaluate with measureUrl and periodStart in request parameters returns 400 and
+    # FHIR Operation Outcome when periodEnd was missing.
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'GET Measure/$evaluate missing periodEnd returns HTTP 400 and OperationOutcome'
+      id 'evaluate-missing-period-end-get-fail'
+      description %(GET Measure/$evaluate with one measureUrl and periodStart returns 400 and
+      FHIR OperationOutcome when periodEnd was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodStart', valueDate: period_start }
+            # periodEnd intentionally omitted
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: FHIR::Parameters.new(body), operation_method: :get)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$evaluate with measureUrl and periodStart in request parameters returns 400 and
+    # FHIR Operation Outcome when periodEnd was missing.
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'POST Measure/$evaluate missing periodEnd returns HTTP 400 and OperationOutcome'
+      id 'evaluate-missing-period-end-post-fail'
+      description %(POST Measure/$evaluate with one measureUrl and periodStart returns 400 and
+      FHIR OperationOutcome when periodEnd was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodStart', valueDate: period_start }
+            # periodEnd intentionally omitted
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: body)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # GET Measure/$evaluate with measureUrl and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when periodStart was missing.
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'GET Measure/$evaluate missing periodStart returns HTTP 400 and OperationOutcome'
+      id 'evaluate-missing-period-start-get-fail'
+      description %(GET Measure/$evaluate with one measureUrl and periodEnd returns 400 and
+      FHIR OperationOutcome when periodStart was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodEnd', valueDate: period_end }
+            # periodStart intentionally omitted
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: FHIR::Parameters.new(body), operation_method: :get)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$evaluate with measureUrl and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when periodStart was missing.
+    test do
+      include MeasureEvaluationHelpers
+
+      title 'POST Measure/$evaluate missing periodStart returns HTTP 400 and OperationOutcome'
+      id 'evaluate-missing-period-start-post-fail'
+      description %(POST Measure/$evaluate with one measureUrl and periodEnd returns 400 and
+      FHIR OperationOutcome when periodStart was missing.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            { name: 'periodEnd', valueDate: period_end }
+            # periodStart intentionally omitted
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: body)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # GET Measure/$evaluate with periodStart and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when measureUrl was missing.
+    test do
+      title 'GET Measure/$evaluate missing measureUrl returns HTTP 400 and OperationOutcome'
+      id 'evaluate-missing-measure-url-get-fail'
+      description %(GET Measure/$evaluate with one periodStart and periodEnd returns 400 and
+      FHIR OperationOutcome when measureUrl was missing.)
+
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+            # measureUrl intentionally omitted
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: FHIR::Parameters.new(body), operation_method: :get)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$evaluate with periodStart and periodEnd in request parameters returns 400 and
+    # FHIR Operation Outcome when measureUrl was missing.
+    test do
+      title 'POST Measure/$evaluate missing measureUrl returns HTTP 400 and OperationOutcome'
+      id 'evaluate-missing-measure-url-post-fail'
+      description %(POST Measure/$evaluate with one periodStart and periodEnd returns 400 and
+      FHIR OperationOutcome when measureUrl was missing.)
+
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+            # measureUrl intentionally omitted
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: body)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # GET Measure/$evaluate with measureUrl, periodStart, periodEnd, subject, and subjectGroup in request parameters
+    # returns 400 and FHIR Operation Outcome for providing both subject and subjectGroup parameters.
+    test do # rubocop:disable Metrics/BlockLength
+      title 'GET Measure/$evaluate with both subject and subjectGroup returns HTTP 400 and OperationOutcome'
+      id 'evaluate-subject-and-subject-group-get-fail'
+      description %(GET Measure/$evaluate with measureUrl, periodStart, periodEnd, subject, and subjectGroup
+      returns 400 and FHIR OperationOutcome when both subject and subjectGroup were provided.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :patient_id, title: 'Patient ID'
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do # rubocop:disable Metrics/BlockLength
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            {
+              name: 'subject',
+              valueString: patient_id
+            },
+            {
+              name: 'subjectGroup',
+              valueString: 'Group/test-group'
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: FHIR::Parameters.new(body), operation_method: :get)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
+
+    # POST Measure/$evaluate with measureUrl, periodStart, periodEnd, subject, and subjectGroup in request parameters
+    # returns 400 and FHIR Operation Outcome for providing both subject and subjectGroup parameters.
+    test do # rubocop:disable Metrics/BlockLength
+      title 'POST Measure/$evaluate with both subject and subjectGroup returns HTTP 400 and OperationOutcome'
+      id 'evaluate-subject-and-subject-group-post-fail'
+      description %(POST Measure/$evaluate with measureUrl, periodStart, periodEnd, subject, and subjectGroup
+      returns 400 and FHIR OperationOutcome when both subject and subjectGroup were provided.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :patient_id, title: 'Patient ID'
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+
+      run do # rubocop:disable Metrics/BlockLength
+        selected_url = selected_measure_url(custom_url: custom_measure_url, url: measure_url)
+        body = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'measureUrl', valueCanonical: selected_url },
+            {
+              name: 'subject',
+              valueString: patient_id
+            },
+            {
+              name: 'subjectGroup',
+              resource: {
+                resourceType: 'Group',
+                id: 'test-group',
+                member: [
+                  {
+                    entity: {
+                      reference: "Patient/#{patient_id}"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              name: 'periodStart',
+              valueDate: period_start
+            },
+            {
+              name: 'periodEnd',
+              valueDate: period_end
+            }
+          ]
+        }
+
+        result = fhir_operation('/Measure/$evaluate', body: body)
+        assert_response_status(400)
+        assert result.resource.is_a?(FHIR::OperationOutcome)
+      end
+    end
   end
 end

--- a/spec/deqm_test_kit/v1.0.0/evaluate_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/evaluate_spec.rb
@@ -171,4 +171,261 @@ RSpec.describe DEQMTestKit::EvaluateV1 do
       expect(result.result).to eq('pass')
     end
   end
+
+  describe 'GET Measure/$evaluate missing periodEnd' do
+    let(:test) { test_by_id(group, 'evaluate-missing-period-end-get-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          periodStart: period_start
+          # periodEnd intentionally omitted
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$evaluate missing periodEnd' do
+    let(:test) { test_by_id(group, 'evaluate-missing-period-end-post-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'measureUrl', valueCanonical: measure_url },
+          { name: 'periodStart', valueDate: period_start }
+          # periodEnd intentionally omitted
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$evaluate missing periodStart' do
+    let(:test) { test_by_id(group, 'evaluate-missing-period-start-get-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          periodEnd: period_end
+          # periodStart intentionally omitted
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$evaluate missing periodStart' do
+    let(:test) { test_by_id(group, 'evaluate-missing-period-start-post-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'measureUrl', valueCanonical: measure_url },
+          { name: 'periodEnd', valueDate: period_end }
+          # periodStart intentionally omitted
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$evaluate missing measureUrl' do
+    let(:test) { test_by_id(group, 'evaluate-missing-measure-url-get-fail') }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        query: {
+          periodStart: period_start,
+          periodEnd: period_end
+          # measureUrl intentionally omitted
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$evaluate missing measureUrl' do
+    let(:test) { test_by_id(group, 'evaluate-missing-measure-url-post-fail') }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: period_start },
+          { name: 'periodEnd', valueDate: period_end }
+          # measureUrl intentionally omitted
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'GET Measure/$evaluate with both subject and subjectGroup' do
+    let(:test) { test_by_id(group, 'evaluate-subject-and-subject-group-get-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:patient_id) { 'test-patient' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      stub_request(
+        :get,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        query: {
+          measureUrl: measure_url,
+          subject: patient_id,
+          subjectGroup: 'Group/test-group',
+          periodStart: period_start,
+          periodEnd: period_end
+        },
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, patient_id:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$evaluate with both subject and subjectGroup' do
+    let(:test) { test_by_id(group, 'evaluate-subject-and-subject-group-post-fail') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:patient_id) { 'test-patient' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+
+    it 'passes with HTTP 400 error and correct OperationOutcome returned' do
+      parameters_request = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'measureUrl', valueCanonical: measure_url },
+          { name: 'subject', valueString: patient_id },
+          {
+            name: 'subjectGroup',
+            resource: {
+              resourceType: 'Group',
+              id: 'test-group',
+              member: [
+                {
+                  entity: {
+                    reference: "Patient/#{patient_id}"
+                  }
+                }
+              ]
+            }
+          },
+          { name: 'periodStart', valueDate: period_start },
+          { name: 'periodEnd', valueDate: period_end }
+        ]
+      }
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$evaluate"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 400, body: error_outcome.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, patient_id:, period_start:, period_end:)
+      expect(result.result).to eq('pass')
+    end
+  end
 end


### PR DESCRIPTION
# Summary
This PR adds 8 fail tests for the $evaluate operation in the Universal Realm STU 1 Test Suite.
## New behavior
- GET Measure/$evaluate with measureUrl and periodStart in request parameters returns 400 and FHIR Operation Outcome when periodEnd was missing.
- POST Measure/$evaluate with measureUrl and periodStart in request body returns 400 and FHIR Operation Outcome when periodEnd was missing.
- GET Measure/$evaluate with measureUrl and periodEnd in request parameters returns 400 and FHIR Operation Outcome when periodStart was missing.
- POST Measure/$evaluate with measureUrl and periodEnd in request body returns 400 and FHIR Operation Outcome when periodStart was missing,
- GET Measure/$evaluate with periodStart and periodEnd in request parameters returns 400 and FHIR Operation Outcome when measureUrl was missing.
- POST Measure/$collect-data with periodStart and periodEnd in request body returns 400 and FHIR Operation Outcome when measureUrl was missing.
- GET Measure/$evaluate with measureUrl, periodStart, periodEnd, subject, and subjectGroup in request parameters returns 400 and FHIR Operation Outcome for providing both subject and subjectGroup parameters.
- POST Measure/$evaluate with measureUrl, periodStart, periodEnd, subject, and subjectGroup in request body returns 400 and FHIR Operation Outcome for providing both subject and subjectGroup parameters.
## Code changes
`lib/deqm-test-kit/evaluate_v1.rb` - Added 8 failure tests.
`spec/deqm-test-kit/v1.0.0/evaluate_spec.rb` - Added corresponding spec tests.
# Testing guidance
In deqm-test-kit:
`bundle exec rspec`
`bundle exec rubocop`
`ASYNC_JOBS=false bundle exec puma`

In deqm-test-server:
`git checkout update-evaluate`
`npm run db:reset`
`npm run upload-bundles`
`npm run start`

In the test kit UI inputs:
Measure URL "Other" radio button
Custom Measure URL: http://ecqi.healthit.gov/ecqms/Measure/ColorectalCancerScreeningsFHIR
url: http://localhost:3000/4_0_1
Measure URL for additional Measure "Other" radio button
Custom Additional Measure URL: http://ecqi.healthit.gov/ecqms/Measure/BreastCancerScreeningsFHIR
Patient ID: Patient-81
