### PR TITLE
collect-data with dataEndpoint param tests

### DIFF
--- a/config/presets/deqm_v100_export_server_flame_demo_suite.json
+++ b/config/presets/deqm_v100_export_server_flame_demo_suite.json
@@ -1,0 +1,35 @@
+{
+  "title": "Bulk Export Server Flame Demo",
+  "id": "deqm_v100_export_server_flame_demo",
+  "test_suite_id": "deqm_v100",
+  "inputs": [
+    {
+      "name": "url",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "https://flame-demo.c3ib.org/bulk-export"
+    },
+    {
+      "name": "measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS165FHIRControllingHighBP"
+    },
+    {
+      "name": "additional_measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS124FHIRCervicalCancerScreen"
+    },
+    {
+      "name": "patient_id",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "6769ebe0-1b45-472a-ba7b-8f9a014d94a6"
+    }
+  ]
+}

--- a/config/presets/deqm_v100_export_server_local_suite.json
+++ b/config/presets/deqm_v100_export_server_local_suite.json
@@ -1,0 +1,35 @@
+{
+  "title": "Bulk Export Server Local",
+  "id": "deqm_v100_export_server_local",
+  "test_suite_id": "deqm_v100",
+  "inputs": [
+    {
+      "name": "url",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "http://localhost:3001"
+    },
+    {
+      "name": "measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS165FHIRControllingHighBP"
+    },
+    {
+      "name": "additional_measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS124FHIRCervicalCancerScreen"
+    },
+    {
+      "name": "patient_id",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "6769ebe0-1b45-472a-ba7b-8f9a014d94a6"
+    }
+  ]
+}

--- a/config/presets/deqm_v100_test_server_flame_demo_suite.json
+++ b/config/presets/deqm_v100_test_server_flame_demo_suite.json
@@ -1,0 +1,42 @@
+{
+  "title": "DEQM Test Server Flame Demo",
+  "id": "deqm_v100_test_server_flame_demo",
+  "test_suite_id": "deqm_v100",
+  "inputs": [
+    {
+      "name": "url",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "https://flame-demo.c3ib.org/deqm-test-server/4_0_1"
+    },
+    {
+      "name": "measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS125FHIRBreastCancerScreen"
+    },
+    {
+      "name": "additional_measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS130FHIRColorectalCancerScrn"
+    },
+    {
+      "name": "patient_id",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "2d526118-fb1d-44c0-9b0b-b8f6d4f2b4fb"
+    },
+    {
+      "name": "data_endpoint",
+      "description": "",
+      "title": "",
+      "type": "textarea",
+      "value": "{\n        \"resourceType\": \"Endpoint\",\n        \"id\": \"example\",\n        \"status\": \"active\",\n        \"connectionType\": {\n          \"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n          \"code\": \"hl7-fhir-rest\"\n        },\n        \"payloadType\": [\n          {\n            \"coding\": [\n              {\n                \"system\": \"http://hl7.org/fhir/resource-types\",\n                \"code\": \"Parameters\"\n              }\n            ]\n          }\n        ],\n        \"payloadMimeType\": [\"application/fhir+json\"],\n        \"address\": \"https://r4.smarthealthit.org\"\n      }"
+    }
+  ]
+}

--- a/config/presets/deqm_v100_test_server_local_suite.json
+++ b/config/presets/deqm_v100_test_server_local_suite.json
@@ -1,0 +1,42 @@
+{
+  "title": "DEQM Test Server Local",
+  "id": "deqm_v100_test_server_local",
+  "test_suite_id": "deqm_v100",
+  "inputs": [
+    {
+      "name": "url",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "http://localhost:3000/4_0_1"
+    },
+    {
+      "name": "measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS125FHIRBreastCancerScreen"
+    },
+    {
+      "name": "additional_measure_url",
+      "description": "",
+      "title": "",
+      "type": "radio",
+      "value": "https://madie.cms.gov/Measure/CMS130FHIRColorectalCancerScrn"
+    },
+    {
+      "name": "patient_id",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "2d526118-fb1d-44c0-9b0b-b8f6d4f2b4fb"
+    },
+    {
+      "name": "data_endpoint",
+      "description": "",
+      "title": "",
+      "type": "textarea",
+      "value": "{\n        \"resourceType\": \"Endpoint\",\n        \"id\": \"example\",\n        \"status\": \"active\",\n        \"connectionType\": {\n          \"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n          \"code\": \"hl7-fhir-rest\"\n        },\n        \"payloadType\": [\n          {\n            \"coding\": [\n              {\n                \"system\": \"http://hl7.org/fhir/resource-types\",\n                \"code\": \"Parameters\"\n              }\n            ]\n          }\n        ],\n        \"payloadMimeType\": [\"application/fhir+json\"],\n        \"address\": \"https://r4.smarthealthit.org\"\n      }"
+    }
+  ]
+}

--- a/lib/deqm_test_kit/collect_data_endpoint_v1.rb
+++ b/lib/deqm_test_kit/collect_data_endpoint_v1.rb
@@ -1,101 +1,11 @@
 # frozen_string_literal: true
 
 require 'json'
+require_relative '../utils/collect_data_utils'
 
 module DEQMTestKit
   # tests for $collect-data (DEQM UV v1.0.0) with dataEndpoint parameter
   class CollectDataEndpointV1 < Inferno::TestGroup
-    # module for shared code for $collect-data with dataEndpoint parameter assertions and requests
-    module CollectDataEndpointHelpers
-      def selected_measure_url(custom_url:, url:, input_title: 'Measure URL',
-                               custom_input_title: 'Custom Measure URL')
-        return url unless url == 'Other'
-
-        custom_url = custom_url.to_s.strip
-
-        assert custom_url.length.positive?,
-               "#{custom_input_title} is required when \"#{input_title}\" is \"Other\"."
-
-        custom_url
-      end
-
-      def selected_additional_measure_url(custom_url:, url:)
-        selected_measure_url(
-          custom_url:,
-          url:,
-          input_title: 'Measure URL for additional Measure',
-          custom_input_title: 'Custom Additional Measure URL'
-        )
-      end
-
-      def selected_measure_urls
-        [
-          selected_measure_url(custom_url: custom_measure_url, url: measure_url),
-          selected_additional_measure_url(custom_url: custom_additional_measure_url, url: additional_measure_url)
-        ]
-      end
-
-      def validate_parameters_contains_bundles(parameters, measure_count)
-        assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
-        assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
-
-        parameters.parameter.each do |param|
-          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
-          validate_bundles_contain_measure_report(param.resource, measure_count)
-        end
-      end
-
-      def validate_number_of_bundles(parameters, bundle_count)
-        assert parameters.parameter.length == bundle_count,
-               "Expected #{bundle_count} Bundle(s), got #{parameters.parameter.length}"
-      end
-
-      def validate_bundles_contain_measure_report(bundle, measure_count)
-        assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
-        assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
-
-        measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
-        assert measure_reports.length == measure_count,
-               "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
-      end
-
-      def collect_data_body(period_start:, period_end:, measure_urls:, data_endpoint:, patient_id:) # rubocop:disable Metrics/MethodLength
-        parameters = measure_urls.map do |url|
-          {
-            name: 'measureUrl',
-            valueCanonical: url
-          }
-        end
-
-        if patient_id
-          parameters << {
-            name: 'subject',
-            valueString: "Patient/#{patient_id}"
-          }
-        end
-
-        parameters << {
-          name: 'periodStart',
-          valueDate: period_start
-        }
-
-        parameters << {
-          name: 'periodEnd',
-          valueDate: period_end
-        }
-
-        parameters << {
-          name: 'dataEndpoint',
-          resource: JSON.parse(data_endpoint)
-        }
-
-        {
-          resourceType: 'Parameters',
-          parameter: parameters
-        }
-      end
-    end
-
     id :collect_data_endpoint_v1
     title '$collect-data with dataEndpoint'
     description 'Ensure FHIR server can perform the $collect-data operation with the dataEndpoint parameter'
@@ -142,7 +52,7 @@ module DEQMTestKit
     }
 
     test do
-      include CollectDataEndpointHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data with one measureUrl, required params, subject Patient, and dataEndpoint'
       id 'collect-data-one-measure-data-endpoint-subject-patient'
@@ -175,7 +85,7 @@ module DEQMTestKit
     end
 
     test do # rubocop:disable Metrics/BlockLength
-      include CollectDataEndpointHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data with two measureUrls, required params, subject Patient, and dataEndpoint'
       id 'collect-data-two-measure-data-endpoint-subject-patient'

--- a/lib/deqm_test_kit/collect_data_endpoint_v1.rb
+++ b/lib/deqm_test_kit/collect_data_endpoint_v1.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module DEQMTestKit
+  # tests for $collect-data (DEQM UV v1.0.0) with dataEndpoint parameter
+  class CollectDataEndpointV1 < Inferno::TestGroup
+    # module for shared code for $collect-data with dataEndpoint parameter assertions and requests
+    module CollectDataEndpointHelpers
+      def selected_measure_url(custom_url:, url:, input_title: 'Measure URL',
+                               custom_input_title: 'Custom Measure URL')
+        return url unless url == 'Other'
+
+        custom_url = custom_url.to_s.strip
+
+        assert custom_url.length.positive?,
+               "#{custom_input_title} is required when \"#{input_title}\" is \"Other\"."
+
+        custom_url
+      end
+
+      def selected_additional_measure_url(custom_url:, url:)
+        selected_measure_url(
+          custom_url:,
+          url:,
+          input_title: 'Measure URL for additional Measure',
+          custom_input_title: 'Custom Additional Measure URL'
+        )
+      end
+
+      def selected_measure_urls
+        [
+          selected_measure_url(custom_url: custom_measure_url, url: measure_url),
+          selected_additional_measure_url(custom_url: custom_additional_measure_url, url: additional_measure_url)
+        ]
+      end
+
+      def validate_parameters_contains_bundles(parameters, measure_count)
+        assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
+        assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
+
+        parameters.parameter.each do |param|
+          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+          validate_bundles_contain_measure_report(param.resource, measure_count)
+        end
+      end
+
+      def validate_number_of_bundles(parameters, bundle_count)
+        assert parameters.parameter.length == bundle_count,
+               "Expected #{bundle_count} Bundle(s), got #{parameters.parameter.length}"
+      end
+
+      def validate_bundles_contain_measure_report(bundle, measure_count)
+        assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
+        assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
+
+        measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
+        assert measure_reports.length == measure_count,
+               "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
+      end
+
+      def collect_data_body(period_start:, period_end:, measure_urls:, data_endpoint:, patient_id:) # rubocop:disable Metrics/MethodLength
+        parameters = measure_urls.map do |url|
+          {
+            name: 'measureUrl',
+            valueCanonical: url
+          }
+        end
+
+        if patient_id
+          parameters << {
+            name: 'subject',
+            valueString: "Patient/#{patient_id}"
+          }
+        end
+
+        parameters << {
+          name: 'periodStart',
+          valueDate: period_start
+        }
+
+        parameters << {
+          name: 'periodEnd',
+          valueDate: period_end
+        }
+
+        parameters << {
+          name: 'dataEndpoint',
+          resource: JSON.parse(data_endpoint)
+        }
+
+        {
+          resourceType: 'Parameters',
+          parameter: parameters
+        }
+      end
+    end
+
+    id :collect_data_endpoint_v1
+    title '$collect-data with dataEndpoint'
+    description 'Ensure FHIR server can perform the $collect-data operation with the dataEndpoint parameter'
+
+    fhir_client do
+      url :url
+      headers origin: url.to_s,
+              referrer: url.to_s,
+              'Content-Type': 'application/fhir+json'
+    end
+
+    measure_options = JSON.parse(File.read('./lib/fixtures/measureUrlRadioButton.json'))
+    measure_url_args = {
+      type: 'radio',
+      optional: false,
+      default: 'https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth',
+      options: measure_options,
+      title: 'Measure URL'
+    }
+    additional_measure_args = {
+      type: 'radio',
+      optional: false,
+      options: measure_options,
+      title: 'Measure URL for additional Measure'
+    }
+    custom_measure_url_args = {
+      type: 'text',
+      optional: true,
+      title: 'Custom Measure URL',
+      description: 'If you selected "Other" above, enter it here.'
+    }
+    custom_additional_measure_url_args = {
+      type: 'text',
+      optional: true,
+      title: 'Custom Additional Measure URL',
+      description: 'If you selected "Other" for the additional Measure URL, enter it here.'
+    }
+
+    data_endpoint_args = {
+      title: 'dataEndpoint',
+      type: 'textarea',
+      description: 'An endpoint resource in JSON format to use to collect the data of interest for the specified
+      measures.'
+    }
+
+    test do
+      include CollectDataEndpointHelpers
+
+      title 'POST Measure/$collect-data with one measureUrl, required params, subject Patient, and dataEndpoint'
+      id 'collect-data-one-measure-data-endpoint-subject-patient'
+      description %(POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, subject Patient, and
+      dataEndpoint returns 200 and FHIR Parameters resource that contains one FHIR Bundle with one FHIR MeasureReport.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :data_endpoint, **data_endpoint_args
+      input :patient_id, title: 'Patient ID'
+
+      run do
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url,
+                                              url: measure_url)], period_start: period_start, period_end: period_end,
+          data_endpoint: data_endpoint, patient_id: patient_id
+        )
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters, 1)
+        validate_number_of_bundles(parameters, 1)
+      end
+    end
+
+    test do # rubocop:disable Metrics/BlockLength
+      include CollectDataEndpointHelpers
+
+      title 'POST Measure/$collect-data with two measureUrls, required params, subject Patient, and dataEndpoint'
+      id 'collect-data-two-measure-data-endpoint-subject-patient'
+      description %(POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, subject Patient, and
+      dataEndpoint returns 200 and FHIR Parameters resource that contains one FHIR Bundle with two FHIR MeasureReports.)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :data_endpoint, **data_endpoint_args
+      input :patient_id, title: 'Patient ID'
+
+      run do
+        body = collect_data_body(
+          measure_urls: selected_measure_urls, period_start: period_start, period_end: period_end,
+          data_endpoint: data_endpoint, patient_id: patient_id
+        )
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+        validate_parameters_contains_bundles(parameters, 2)
+        validate_number_of_bundles(parameters, 1)
+      end
+    end
+  end
+end

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -1,97 +1,12 @@
 # frozen_string_literal: true
 
 require 'json'
+require_relative '../utils/collect_data_utils'
 
 module DEQMTestKit
   # tests for $collect-data (DEQM UV v1.0.0)
   # rubocop:disable Metrics/ClassLength
   class CollectDataV1 < Inferno::TestGroup
-    # module for shared code for $collect-data assertions and requests
-    module CollectDataHelpers
-      def selected_measure_url(custom_url:, url:, input_title: 'Measure URL',
-                               custom_input_title: 'Custom Measure URL')
-        return url unless url == 'Other'
-
-        custom_url = custom_url.to_s.strip
-
-        assert custom_url.length.positive?,
-               "#{custom_input_title} is required when \"#{input_title}\" is \"Other\"."
-
-        custom_url
-      end
-
-      def selected_additional_measure_url(custom_url:, url:)
-        selected_measure_url(
-          custom_url:,
-          url:,
-          input_title: 'Measure URL for additional Measure',
-          custom_input_title: 'Custom Additional Measure URL'
-        )
-      end
-
-      def selected_measure_urls
-        [
-          selected_measure_url(custom_url: custom_measure_url, url: measure_url),
-          selected_additional_measure_url(custom_url: custom_additional_measure_url, url: additional_measure_url)
-        ]
-      end
-
-      def validate_parameters_contains_bundles(parameters, measure_count)
-        assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
-        assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
-
-        parameters.parameter.each do |param|
-          assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
-          validate_bundles_contain_measure_report(param.resource, measure_count)
-        end
-      end
-
-      def validate_number_of_bundles(parameters, bundle_count)
-        assert parameters.parameter.length == bundle_count,
-               "Expected #{bundle_count} Bundle(s), got #{parameters.parameter.length}"
-      end
-
-      def validate_bundles_contain_measure_report(bundle, measure_count)
-        assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
-        assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
-
-        measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
-        assert measure_reports.length == measure_count,
-               "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
-      end
-
-      def collect_data_body(period_start:, period_end:, measure_urls:, patient_id: nil) # rubocop:disable Metrics/MethodLength
-        parameters = measure_urls.map do |url|
-          {
-            name: 'measureUrl',
-            valueCanonical: url
-          }
-        end
-
-        if patient_id
-          parameters << {
-            name: 'subject',
-            valueString: "Patient/#{patient_id}"
-          }
-        end
-
-        parameters << {
-          name: 'periodStart',
-          valueDate: period_start
-        }
-
-        parameters << {
-          name: 'periodEnd',
-          valueDate: period_end
-        }
-
-        {
-          resourceType: 'Parameters',
-          parameter: parameters
-        }
-      end
-    end
-
     id :collect_data_v1
     title '$collect-data'
     description 'Ensure FHIR server can perform the $collect-data operation'
@@ -131,7 +46,7 @@ module DEQMTestKit
     }
 
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'GET Measure/$collect-data with one measureUrl, periodStart, periodEnd'
       id 'collect-data-one-measure-get'
@@ -161,7 +76,7 @@ module DEQMTestKit
     end
 
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd'
       id 'collect-data-one-measure-post'
@@ -190,7 +105,7 @@ module DEQMTestKit
     end
 
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'GET Measure/$collect-data with two measureUrls, periodStart, periodEnd'
       id 'collect-data-two-measure-get'
@@ -223,7 +138,7 @@ module DEQMTestKit
     end
 
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd'
       id 'collect-data-two-measure-post'
@@ -255,7 +170,7 @@ module DEQMTestKit
     end
 
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'GET Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subject=Patient/patientId'
       id 'collect-data-one-measure-get-subject-patient'
@@ -290,7 +205,7 @@ module DEQMTestKit
     end
 
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subject=Patient/patientId'
       id 'collect-data-one-measure-post-subject-patient'
@@ -325,7 +240,7 @@ module DEQMTestKit
     end
 
     test do # rubocop:disable Metrics/BlockLength
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'GET Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subject=Patient/patientId'
       id 'collect-data-two-measure-get-subject-patient'
@@ -362,7 +277,7 @@ module DEQMTestKit
     end
 
     test do # rubocop:disable Metrics/BlockLength
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subject=Patient/patientId'
       id 'collect-data-two-measure-post-subject-patient'
@@ -400,7 +315,7 @@ module DEQMTestKit
     # GET Measure/$collect-data with measureUrl and periodStart in request parameters returns 400 and
     # FHIR Operation Outcome when periodEnd was missing.
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'GET Measure/$collect-data missing periodEnd returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-end-get-fail'
@@ -431,7 +346,7 @@ module DEQMTestKit
     # POST Measure/$collect-data with measureUrl and periodStart in request body returns 400 and
     # FHIR Operation Outcome when periodEnd was missing.
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data missing periodEnd returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-end-post-fail'
@@ -462,7 +377,7 @@ module DEQMTestKit
     # GET Measure/$collect-data with measureUrl and periodEnd in request parameters returns 400 and
     # FHIR Operation Outcome when periodStart was missing.
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'GET Measure/$collect-data missing periodStart returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-start-get-fail'
@@ -493,7 +408,7 @@ module DEQMTestKit
     # POST Measure/$collect-data with measureUrl and periodEnd in request body returns 400 and
     # FHIR Operation Outcome when periodStart was missing.
     test do
-      include CollectDataHelpers
+      include CollectDataUtils
 
       title 'POST Measure/$collect-data missing periodStart returns HTTP 400 and OperationOutcome'
       id 'collect-data-missing-period-start-post-fail'

--- a/lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb
+++ b/lib/deqm_test_kit/v1.0.0/deqm_test_suite.rb
@@ -2,6 +2,7 @@
 
 require_relative '../evaluate_v1'
 require_relative '../collect_data_v1'
+require_relative '../collect_data_endpoint_v1'
 
 module DEQMTestKit
   # Test suite for DEQM Universal Realm Version 1.0.0
@@ -41,6 +42,7 @@ module DEQMTestKit
 
       group from: :evaluate_v1
       group from: :collect_data_v1
+      group from: :collect_data_endpoint_v1
     end
   end
 end

--- a/lib/fixtures/measureUrlRadioButton.json
+++ b/lib/fixtures/measureUrlRadioButton.json
@@ -1,44 +1,56 @@
 {
   "list_options": [
     {
-      "label": "CMS0334FHIRPCCesareanBirth",
-      "value": "https://madie.cms.gov/Measure/CMS0334FHIRPCCesareanBirth"
-    },
-    {
-      "label": "CMS1017FHIRHHFI",
-      "value": "https://madie.cms.gov/Measure/CMS1017FHIRHHFI"
-    },
-    {
-      "label": "CMS1056CTClinicalFHIR",
-      "value": "https://madie.cms.gov/Measure/CMS1056CTClinicalFHIR"
-    },
-    {
-      "label": "CMS1074FHIRCTIQR",
-      "value": "https://madie.cms.gov/Measure/CMS1074FHIRCTIQR"
-    },
-    {
-      "label": "CMS108FHIRVTEProphylaxis",
-      "value": "https://madie.cms.gov/Measure/CMS108FHIRVTEProphylaxis"
-    },
-    {
-      "label": "CMS117FHIRChildhoodImmunizationStatus",
-      "value": "https://madie.cms.gov/Measure/CMS117FHIRChildhoodImmunizationStatus"
-    },
-    {
-      "label": "CMS1218FHIRHHRF",
-      "value": "https://madie.cms.gov/Measure/CMS1218FHIRHHRF"
+      "label": "CMS2FHIRPCSDepScreenAndFollowUp",
+      "value": "https://madie.cms.gov/Measure/CMS2FHIRPCSDepScreenAndFollowUp"
     },
     {
       "label": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
       "value": "https://madie.cms.gov/Measure/CMS122FHIRDiabetesAssessGreaterThan9Percent"
     },
     {
-      "label": "CMS1244FHIRECATHOQR",
-      "value": "https://madie.cms.gov/Measure/CMS1244FHIRECATHOQR"
-    },
-    {
       "label": "CMS124FHIRCervicalCancerScreening",
       "value": "https://madie.cms.gov/Measure/CMS124FHIRCervicalCancerScreening"
+    },
+    {
+      "label": "CMS125FHIRBreastCancerScreen",
+      "value": "https://madie.cms.gov/Measure/CMS125FHIRBreastCancerScreen"
+    },
+    {
+      "label": "CMS130FHIRColorectalCancerScrn",
+      "value": "https://madie.cms.gov/Measure/CMS130FHIRColorectalCancerScrn"
+    },
+    {
+      "label": "CMS165FHIRControllingHighBP",
+      "value": "https://madie.cms.gov/Measure/CMS165FHIRControllingHighBP"
+    },
+    {
+      "label": "CMSFHIR529HybridHospitalWideReadmission",
+      "value": "https://madie.cms.gov/Measure/CMSFHIR529HybridHospitalWideReadmission"
+    },
+    {
+      "label": "CMS506FHIRSafeUseofOpioids",
+      "value": "https://madie.cms.gov/Measure/CMS506FHIRSafeUseofOpioids"
+    },
+    {
+      "label": "CMS71FHIRSTKAnticoagAFFlutter",
+      "value": "https://madie.cms.gov/Measure/CMS71FHIRSTKAnticoagAFFlutter"
+    },
+    {
+      "label": "CMS816FHIRHHHypo",
+      "value": "https://madie.cms.gov/Measure/CMS816FHIRHHHypo"
+    },
+    {
+      "label": "CMS1017FHIRHHFI",
+      "value": "https://madie.cms.gov/Measure/CMS1017FHIRHHFI"
+    },
+    {
+      "label": "CMS1028FHIRPCSevereOBComps",
+      "value": "https://madie.cms.gov/Measure/CMS1028FHIRPCSevereOBComps"
+    },
+    {
+      "label": "CMS1218FHIRHHRF",
+      "value": "https://madie.cms.gov/Measure/CMS1218FHIRHHRF"
     },
     {
       "label": "Other",

--- a/lib/fixtures/measureUrlRadioButton.json
+++ b/lib/fixtures/measureUrlRadioButton.json
@@ -5,12 +5,12 @@
       "value": "https://madie.cms.gov/Measure/CMS2FHIRPCSDepScreenAndFollowUp"
     },
     {
-      "label": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
-      "value": "https://madie.cms.gov/Measure/CMS122FHIRDiabetesAssessGreaterThan9Percent"
+      "label": "CMS122FHIRDiabetesAssessGT9Pct",
+      "value": "https://madie.cms.gov/Measure/CMS122FHIRDiabetesAssessGT9Pct"
     },
     {
-      "label": "CMS124FHIRCervicalCancerScreening",
-      "value": "https://madie.cms.gov/Measure/CMS124FHIRCervicalCancerScreening"
+      "label": "CMS124FHIRCervicalCancerScreen",
+      "value": "https://madie.cms.gov/Measure/CMS124FHIRCervicalCancerScreen"
     },
     {
       "label": "CMS125FHIRBreastCancerScreen",

--- a/lib/utils/collect_data_utils.rb
+++ b/lib/utils/collect_data_utils.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module DEQMTestKit
+  # Utility functions in support of the collect-data test groups
+  module CollectDataUtils
+    def selected_measure_url(custom_url:, url:, input_title: 'Measure URL',
+                             custom_input_title: 'Custom Measure URL')
+      return url unless url == 'Other'
+
+      custom_url = custom_url.to_s.strip
+
+      assert custom_url.length.positive?,
+             "#{custom_input_title} is required when \"#{input_title}\" is \"Other\"."
+
+      custom_url
+    end
+
+    def selected_additional_measure_url(custom_url:, url:)
+      selected_measure_url(
+        custom_url:,
+        url:,
+        input_title: 'Measure URL for additional Measure',
+        custom_input_title: 'Custom Additional Measure URL'
+      )
+    end
+
+    def selected_measure_urls
+      [
+        selected_measure_url(custom_url: custom_measure_url, url: measure_url),
+        selected_additional_measure_url(custom_url: custom_additional_measure_url, url: additional_measure_url)
+      ]
+    end
+
+    def validate_parameters_contains_bundles(parameters, measure_count)
+      assert parameters.parameter.is_a?(Array), 'Expected Parameters.parameter to be an array'
+      assert parameters.parameter.any?, 'Expected at least one parameter entry in Parameters resource'
+
+      parameters.parameter.each do |param|
+        assert param.resource.is_a?(FHIR::Bundle), 'Expected parameter.resource to be a Bundle'
+        validate_bundles_contain_measure_report(param.resource, measure_count)
+      end
+    end
+
+    def validate_number_of_bundles(parameters, bundle_count)
+      assert parameters.parameter.length == bundle_count,
+             "Expected #{bundle_count} Bundle(s), got #{parameters.parameter.length}"
+    end
+
+    def validate_bundles_contain_measure_report(bundle, measure_count)
+      assert bundle.entry.is_a?(Array), 'Expected Bundle.entry to be an array'
+      assert bundle.entry.any?, 'Expected at least one entry in the Bundle'
+
+      measure_reports = bundle.entry.map(&:resource).grep(FHIR::MeasureReport)
+      assert measure_reports.length == measure_count,
+             "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
+    end
+
+    def collect_data_body(period_start:, period_end:, measure_urls:, patient_id: nil, data_endpoint: nil) # rubocop:disable Metrics/MethodLength
+      parameters = measure_urls.map do |url|
+        {
+          name: 'measureUrl',
+          valueCanonical: url
+        }
+      end
+
+      if patient_id
+        parameters << {
+          name: 'subject',
+          valueString: "Patient/#{patient_id}"
+        }
+      end
+
+      parameters << {
+        name: 'periodStart',
+        valueDate: period_start
+      }
+
+      parameters << {
+        name: 'periodEnd',
+        valueDate: period_end
+      }
+
+      if data_endpoint
+        parameters << {
+          name: 'dataEndpoint',
+          resource: JSON.parse(data_endpoint)
+        }
+      end
+
+      {
+        resourceType: 'Parameters',
+        parameter: parameters
+      }
+    end
+  end
+end

--- a/spec/deqm_test_kit/v1.0.0/collect_data_endpoint_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_endpoint_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative '../../utils/collect_data_spec_utils'
+
+RSpec.describe DEQMTestKit::CollectDataEndpointV1 do
+  include DEQMTestKit::CollectDataSpecUtils
+
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_v100') }
+  let(:group) { suite.groups[3] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:data_endpoint) do
+    {
+      resourceType: 'Endpoint',
+      status: 'active',
+      connectionType: { system: 'http://terminology.hl7.org/CodeSystem/endpoint-connection-type',
+                        code: 'hl7-fhir-rest' },
+      address: 'https://r4.smarthealthit.org'
+    }.to_json
+  end
+
+  describe 'POST Measure/$collect-data with one measureUrl, subject, and dataEndpoint' do
+    let(:test) { test_by_id(group, 'collect-data-one-measure-data-endpoint-subject-patient') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_id) { 'numer-EXM130' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      parameters_request = create_parameters_request(
+        measure_urls: [measure_url], period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => url,
+          'Referrer' => url
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:, patient_id:, data_endpoint:)
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  describe 'POST Measure/$collect-data with two measureUrls, subject, and dataEndpoint' do
+    let(:test) { test_by_id(group, 'collect-data-two-measure-data-endpoint-subject-patient') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_id) { 'numer-EXM130' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      measure_urls = [measure_url, additional_measure_url]
+      parameters_request = create_parameters_request(
+        measure_urls:, period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      parameters_response = create_parameters_response(measure_urls:)
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => url,
+          'Referrer' => url
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(
+        test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      expect(result.result).to eq('pass')
+    end
+  end
+end

--- a/spec/deqm_test_kit/v1.0.0/collect_data_endpoint_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_endpoint_spec.rb
@@ -16,7 +16,17 @@ RSpec.describe DEQMTestKit::CollectDataEndpointV1 do
       status: 'active',
       connectionType: { system: 'http://terminology.hl7.org/CodeSystem/endpoint-connection-type',
                         code: 'hl7-fhir-rest' },
-      address: 'https://r4.smarthealthit.org'
+      address: 'example.com/data',
+      payloadType: [
+        {
+          coding: [
+            {
+              system: 'http://hl7.org/fhir/resource-types',
+              code: 'Parameters'
+            }
+          ]
+        }
+      ]
     }.to_json
   end
 
@@ -80,6 +90,55 @@ RSpec.describe DEQMTestKit::CollectDataEndpointV1 do
         test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_id:, data_endpoint:
       )
       expect(result.result).to eq('pass')
+    end
+
+    it 'fails if result is not a Parameters resource' do
+      measure_urls = [measure_url, additional_measure_url]
+      parameters_request = create_parameters_request(
+        measure_urls:, period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      parameters_response = { resourceType: 'Invalid' }
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => url,
+          'Referrer' => url
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(
+        test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/Parameters/)
+    end
+
+    it 'fails if result has incorrect number of measure reports' do
+      measure_urls = [measure_url, additional_measure_url]
+      parameters_request = create_parameters_request(
+        measure_urls:, period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => url,
+          'Referrer' => url
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(
+        test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_id:, data_endpoint:
+      )
+      expect(result.result).to eq('fail')
     end
   end
 end

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -1,55 +1,19 @@
 # frozen_string_literal: true
 
+require_relative '../../utils/collect_data_spec_utils'
+
 INVALID_MEASURE_ID = 'INVALID_MEASURE_ID'
 INVALID_START_DATE = 'INVALID_START_DATE'
 
 RSpec.describe DEQMTestKit::CollectDataV1 do
+  include DEQMTestKit::CollectDataSpecUtils
+
   let(:suite) { Inferno::Repositories::TestSuites.new.find('deqm_v100') }
   let(:group) { suite.groups[2] }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-
-  # Helper method to create a valid Parameters resource
-  def create_parameters_response(measure_urls:) # rubocop:disable Metrics/MethodLength
-    measure_reports = measure_urls.map do |url|
-      FHIR::MeasureReport.new(
-        status: 'complete', type: 'data-collection',
-        measure: url,
-        period: { start: '2019-01-01', end: '2019-12-31' }
-      )
-    end
-
-    bundle = FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
-
-    FHIR::Parameters.new(parameter:
-      {
-        name: 'return',
-        resource: bundle
-      })
-  end
-
-  def create_parameters_request(measure_urls:, period_start:, period_end:, patient_id: nil)
-    parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
-    parameters << { name: 'subject', valueString: "Patient/#{patient_id}" } if patient_id
-    parameters << { name: 'periodStart', valueDate: period_start }
-    parameters << { name: 'periodEnd', valueDate: period_end }
-
-    {
-      resourceType: 'Parameters',
-      parameter: parameters
-    }
-  end
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(test_session_id: test_session.id, name:, value:, type: 'text')
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
 
   describe 'GET Measure/$collect-data with one measureUrl and required params' do
     let(:test) { test_by_id(group, 'collect-data-one-measure-get') }

--- a/spec/utils/collect_data_spec_utils.rb
+++ b/spec/utils/collect_data_spec_utils.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module DEQMTestKit
+  # Helpers shared by $collect-data specs
+  module CollectDataSpecUtils
+    def create_parameters_response(measure_urls:)
+      measure_reports = measure_urls.map do |url|
+        FHIR::MeasureReport.new(
+          status: 'complete', type: 'data-collection',
+          measure: url,
+          period: { start: '2019-01-01', end: '2019-12-31' }
+        )
+      end
+      bundle = FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
+
+      FHIR::Parameters.new(parameter: { name: 'return', resource: bundle })
+    end
+
+    def create_parameters_request(measure_urls:, period_start:, period_end:, patient_id: nil, data_endpoint: nil)
+      parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
+      parameters << { name: 'subject', valueString: "Patient/#{patient_id}" } if patient_id
+      parameters << { name: 'periodStart', valueDate: period_start }
+      parameters << { name: 'periodEnd', valueDate: period_end }
+      parameters << { name: 'dataEndpoint', resource: JSON.parse(data_endpoint) } if data_endpoint
+
+      {
+        resourceType: 'Parameters',
+        parameter: parameters
+      }
+    end
+
+    def run(runnable, inputs = {})
+      test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+      test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+      inputs.each do |name, value|
+        session_data_repo.save(test_session_id: test_session.id, name:, value:, type: 'text')
+      end
+      Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This PR adds two `$collect-data` operation tests, specifically for a POST to `$collect-data` with the `dataEndpoint` parameter.

## New behavior
New test group added (separated this from the other `$collect-data` test group because our implementations of `$collect-data` are different between our `bulk-export-server` (doesn't support `dataEndpoint`) and `deqm-test-server` (only supports `dataEndoint`). Also adds some STU1 test suite presets.

## Code changes
- `config/presents/` - added presets for local and flame-demo instances of `deqm-test-server` and `bulk-export-server`. `bulk-export-server` used for the $collect-data (without dataEndpoint) test group, `deqm-test-server` used for the rest
- `collect_data_endpoint_v1.rb` - collect-data test group separate from collect-data because it requires the dataEndpoint parameter
- `measureUrlRadioButton.json` - updated radio buttons to match dqm-content-qicore-2025.

# Testing guidance
In deqm-test-kit:
- `bundle exec rubocop`
- `bundle exec rspec` (didn't add any spec tests yet to focus on the cthon)
- `ASYNC_JOBS=false bundle exec puma`
- Use the DEQM Test Server Local preset

In deqm-test-server:
- `npm run start`