### PR TITLE
add collect_data tests with subjectGroup parameter

### DIFF
--- a/config/presets/deqm_v100_export_server_flame_demo_suite.json
+++ b/config/presets/deqm_v100_export_server_flame_demo_suite.json
@@ -30,6 +30,13 @@
       "title": "",
       "type": "text",
       "value": "6769ebe0-1b45-472a-ba7b-8f9a014d94a6"
+    },
+    {
+      "name": "patient_ids",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "f6dafa7e-15a9-4fec-baea-59d43201caf8, c58acff5-248b-49c9-b18d-69e4a84a08d9"
     }
   ]
 }

--- a/config/presets/deqm_v100_export_server_local_suite.json
+++ b/config/presets/deqm_v100_export_server_local_suite.json
@@ -30,6 +30,13 @@
       "title": "",
       "type": "text",
       "value": "6769ebe0-1b45-472a-ba7b-8f9a014d94a6"
+    },
+    {
+      "name": "patient_ids",
+      "description": "",
+      "title": "",
+      "type": "text",
+      "value": "f6dafa7e-15a9-4fec-baea-59d43201caf8, c58acff5-248b-49c9-b18d-69e4a84a08d9"
     }
   ]
 }

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -312,6 +312,88 @@ module DEQMTestKit
       end
     end
 
+    test do # rubocop:disable Metrics/BlockLength
+      include CollectDataUtils
+
+      title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subjectGroup'
+      id 'collect-data-one-measure-post-subject-group'
+      description %(POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and
+      subjectGroup returns 200 and FHIR Parameters resource that contains X number of FHIR Bundles that
+      each contain one MeasureReport)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :patient_ids,
+            title: 'Patient IDs',
+            description: 'Enter a comma-delimited list of patient IDs.'
+
+      run do
+        patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+
+        body = collect_data_body(
+          measure_urls: [selected_measure_url(custom_url: custom_measure_url, url: measure_url)],
+          period_start: period_start,
+          period_end: period_end,
+          patient_id_list: patient_id_list
+        )
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+
+        validate_parameters_contains_bundles(parameters, 1)
+        validate_number_of_bundles(parameters, patient_id_list.length)
+      end
+    end
+
+    test do # rubocop:disable Metrics/BlockLength
+      include CollectDataUtils
+
+      title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subjectGroup'
+      id 'collect-data-two-measures-post-subject-group'
+      description %(POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and
+      subjectGroup returns 200 and FHIR Parameters resource that contains X number of FHIR Bundles that
+      each contain two MeasureReports)
+
+      input :measure_url, **measure_url_args
+      input :custom_measure_url, **custom_measure_url_args
+      input :additional_measure_url, **additional_measure_args
+      input :custom_additional_measure_url, **custom_additional_measure_url_args
+      input :period_start, title: 'Measurement Period Start', default: '2026-01-01'
+      input :period_end, title: 'Measurement Period End', default: '2026-12-31'
+      input :patient_ids,
+            title: 'Patient IDs',
+            description: 'Enter a comma-delimited list of patient IDs.'
+
+      run do
+        patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+
+        body = collect_data_body(
+          measure_urls: selected_measure_urls,
+          period_start: period_start,
+          period_end: period_end,
+          patient_id_list: patient_id_list
+        )
+
+        result = fhir_operation('/Measure/$collect-data', body: body)
+
+        assert_response_status(200)
+        assert result.resource.is_a?(FHIR::Parameters), "Expected
+        resource to be a Parameters resource, but got #{result.resource&.class}"
+
+        parameters = result.resource
+
+        validate_parameters_contains_bundles(parameters, 2)
+        validate_number_of_bundles(parameters, patient_id_list.length)
+      end
+    end
+
     # GET Measure/$collect-data with measureUrl and periodStart in request parameters returns 400 and
     # FHIR Operation Outcome when periodEnd was missing.
     test do

--- a/lib/deqm_test_kit/collect_data_v1.rb
+++ b/lib/deqm_test_kit/collect_data_v1.rb
@@ -318,8 +318,8 @@ module DEQMTestKit
       title 'POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and subjectGroup'
       id 'collect-data-one-measure-post-subject-group'
       description %(POST Measure/$collect-data with one measureUrl, periodStart, periodEnd, and
-      subjectGroup returns 200 and FHIR Parameters resource that contains X number of FHIR Bundles that
-      each contain one MeasureReport)
+      subjectGroup returns 200 and FHIR Parameters resource that contains X (patient count)
+      number of FHIR Bundles that each contain one MeasureReport)
 
       input :measure_url, **measure_url_args
       input :custom_measure_url, **custom_measure_url_args
@@ -358,8 +358,8 @@ module DEQMTestKit
       title 'POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and subjectGroup'
       id 'collect-data-two-measures-post-subject-group'
       description %(POST Measure/$collect-data with two measureUrls, periodStart, periodEnd, and
-      subjectGroup returns 200 and FHIR Parameters resource that contains X number of FHIR Bundles that
-      each contain two MeasureReports)
+      subjectGroup returns 200 and FHIR Parameters resource that contains X (patient count)
+      number of FHIR Bundles that each contain two MeasureReports)
 
       input :measure_url, **measure_url_args
       input :custom_measure_url, **custom_measure_url_args

--- a/lib/utils/collect_data_utils.rb
+++ b/lib/utils/collect_data_utils.rb
@@ -57,7 +57,9 @@ module DEQMTestKit
              "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
     end
 
-    def collect_data_body(period_start:, period_end:, measure_urls:, patient_id: nil, data_endpoint: nil) # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def collect_data_body(period_start:, period_end:, measure_urls:, patient_id: nil,
+                          patient_id_list: nil, data_endpoint: nil)
       parameters = measure_urls.map do |url|
         {
           name: 'measureUrl',
@@ -69,6 +71,19 @@ module DEQMTestKit
         parameters << {
           name: 'subject',
           valueString: "Patient/#{patient_id}"
+        }
+      end
+
+      if patient_id_list
+        parameters << {
+          name: 'subjectGroup',
+          resource: {
+            resourceType: 'Group',
+            id: 'test-group-subjectGroup',
+            member: patient_id_list.map do |group_patient_id|
+              { entity: { reference: "Patient/#{group_patient_id}" } }
+            end
+          }
         }
       end
 
@@ -94,5 +109,6 @@ module DEQMTestKit
         parameter: parameters
       }
     end
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
   end
 end

--- a/lib/utils/collect_data_utils.rb
+++ b/lib/utils/collect_data_utils.rb
@@ -57,31 +57,32 @@ module DEQMTestKit
              "Expected #{measure_count} MeasureReport(s), got #{measure_reports.length}"
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
-    def collect_data_body(period_start:, period_end:, measure_urls:, patient_id: nil,
-                          patient_id_list: nil, data_endpoint: nil)
-      parameters = measure_urls.map do |url|
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def collect_data_body(options)
+      parameters = options[:measure_urls].map do |url|
         {
           name: 'measureUrl',
           valueCanonical: url
         }
       end
 
-      if patient_id
+      if options[:patient_id]
         parameters << {
           name: 'subject',
-          valueString: "Patient/#{patient_id}"
+          valueString: "Patient/#{options[:patient_id]}"
         }
       end
 
-      if patient_id_list
+      if options[:patient_id_list]
         parameters << {
           name: 'subjectGroup',
           resource: {
             resourceType: 'Group',
             id: 'test-group-subjectGroup',
-            member: patient_id_list.map do |group_patient_id|
-              { entity: { reference: "Patient/#{group_patient_id}" } }
+            type: 'person',
+            actual: true,
+            member: options[:patient_id_list].map do |patient_id|
+              { entity: { reference: "Patient/#{patient_id}" } }
             end
           }
         }
@@ -89,18 +90,18 @@ module DEQMTestKit
 
       parameters << {
         name: 'periodStart',
-        valueDate: period_start
+        valueDate: options[:period_start]
       }
 
       parameters << {
         name: 'periodEnd',
-        valueDate: period_end
+        valueDate: options[:period_end]
       }
 
-      if data_endpoint
+      if options[:data_endpoint]
         parameters << {
           name: 'dataEndpoint',
-          resource: JSON.parse(data_endpoint)
+          resource: JSON.parse(options[:data_endpoint])
         }
       end
 
@@ -109,6 +110,6 @@ module DEQMTestKit
         parameter: parameters
       }
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end
 end

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -275,25 +275,8 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       parameters_request = create_parameters_request(
         measure_urls: [measure_url], period_start:, period_end:, patient_id_list:
       )
-      parameters_response = FHIR::Parameters.new(
-        parameter: patient_id_list.map do
-          FHIR::Parameters::Parameter.new(
-            name: 'return',
-            resource: FHIR::Bundle.new(
-              type: 'transaction',
-              entry: [
-                {
-                  resource: FHIR::MeasureReport.new(
-                    status: 'complete',
-                    type: 'data-collection',
-                    measure: measure_url,
-                    period: { start: period_start, end: period_end }
-                  )
-                }
-              ]
-            )
-          )
-        end
+      parameters_response = create_parameters_response(
+        measure_urls: [measure_url], patient_ids: patient_id_list
       )
 
       stub_request(
@@ -381,26 +364,7 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       parameters_request = create_parameters_request(
         measure_urls:, period_start:, period_end:, patient_id_list:
       )
-      parameters_response = FHIR::Parameters.new(
-        parameter: patient_id_list.map do
-          FHIR::Parameters::Parameter.new(
-            name: 'return',
-            resource: FHIR::Bundle.new(
-              type: 'transaction',
-              entry: measure_urls.map do |measure_url|
-                {
-                  resource: FHIR::MeasureReport.new(
-                    status: 'complete',
-                    type: 'data-collection',
-                    measure: measure_url,
-                    period: { start: period_start, end: period_end }
-                  )
-                }
-              end
-            )
-          )
-        end
-      )
+      parameters_response = create_parameters_response(measure_urls:, patient_ids: patient_id_list)
 
       stub_request(:post, "#{url}/Measure/$collect-data").with(
         body: parameters_request.to_json,

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
         measure_urls: [measure_url], period_start:, period_end:, patient_id_list:
       )
       parameters_response = create_parameters_response(
-        measure_urls: [measure_url], patient_ids: patient_id_list
+        measure_urls: [measure_url], bundle_count: patient_id_list.length
       )
 
       stub_request(
@@ -300,17 +300,8 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       parameters_request = create_parameters_request(
         measure_urls: [measure_url], period_start:, period_end:, patient_id_list:
       )
-      parameters_response = FHIR::Parameters.new(
-        parameter: patient_id_list.map do
-          FHIR::Parameters::Parameter.new(
-            name: 'return',
-            resource: FHIR::Bundle.new(
-              type: 'transaction',
-              entry: [] # no measure reports
-            )
-          )
-        end
-      )
+      parameters_response = create_parameters_response(measure_urls: [measure_url, measure_url],
+                                                       bundle_count: patient_id_list.length)
 
       stub_request(
         :post, "#{url}/Measure/$collect-data"
@@ -364,7 +355,7 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       parameters_request = create_parameters_request(
         measure_urls:, period_start:, period_end:, patient_id_list:
       )
-      parameters_response = create_parameters_response(measure_urls:, patient_ids: patient_id_list)
+      parameters_response = create_parameters_response(measure_urls:, bundle_count: patient_id_list.length)
 
       stub_request(:post, "#{url}/Measure/$collect-data").with(
         body: parameters_request.to_json,
@@ -385,26 +376,8 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
       parameters_request = create_parameters_request(
         measure_urls:, period_start:, period_end:, patient_id_list:
       )
-      parameters_response = FHIR::Parameters.new(
-        parameter: patient_id_list.map do
-          FHIR::Parameters::Parameter.new(
-            name: 'return',
-            resource: FHIR::Bundle.new(
-              type: 'transaction',
-              entry: [
-                {
-                  resource: FHIR::MeasureReport.new(
-                    status: 'complete',
-                    type: 'data-collection',
-                    measure: measure_url,
-                    period: { start: period_start, end: period_end }
-                  )
-                }
-              ]
-            )
-          )
-        end
-      )
+      parameters_response = create_parameters_response(measure_urls: [measure_url],
+                                                       bundle_count: patient_id_list.length)
 
       stub_request(
         :post, "#{url}/Measure/$collect-data"

--- a/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
+++ b/spec/deqm_test_kit/v1.0.0/collect_data_spec.rb
@@ -263,6 +263,224 @@ RSpec.describe DEQMTestKit::CollectDataV1 do
     end
   end
 
+  describe 'POST Measure/$collect-data with one measureUrl and subjectGroup' do
+    let(:test) { test_by_id(group, 'collect-data-one-measure-post-subject-group') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_ids) { 'patient-1, patient-2' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+      parameters_request = create_parameters_request(
+        measure_urls: [measure_url], period_start:, period_end:, patient_id_list:
+      )
+      parameters_response = FHIR::Parameters.new(
+        parameter: patient_id_list.map do
+          FHIR::Parameters::Parameter.new(
+            name: 'return',
+            resource: FHIR::Bundle.new(
+              type: 'transaction',
+              entry: [
+                {
+                  resource: FHIR::MeasureReport.new(
+                    status: 'complete',
+                    type: 'data-collection',
+                    measure: measure_url,
+                    period: { start: period_start, end: period_end }
+                  )
+                }
+              ]
+            )
+          )
+        end
+      )
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:, patient_ids:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if result has incorrect number of measure reports' do
+      patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+      parameters_request = create_parameters_request(
+        measure_urls: [measure_url], period_start:, period_end:, patient_id_list:
+      )
+      parameters_response = FHIR::Parameters.new(
+        parameter: patient_id_list.map do
+          FHIR::Parameters::Parameter.new(
+            name: 'return',
+            resource: FHIR::Bundle.new(
+              type: 'transaction',
+              entry: [] # no measure reports
+            )
+          )
+        end
+      )
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:, patient_ids:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if result has incorrect number of bundles' do
+      patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+      parameters_request = create_parameters_request(
+        measure_urls: [measure_url], period_start:, period_end:, patient_id_list:
+      )
+      parameters_response = create_parameters_response(measure_urls: [measure_url])
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, period_start:, period_end:, patient_ids:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'POST Measure/$collect-data with two measureUrls and subjectGroup' do
+    let(:test) { test_by_id(group, 'collect-data-two-measures-post-subject-group') }
+    let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }
+    let(:additional_measure_url) { 'http://example.com/Measure/measure-EXM124' }
+    let(:period_start) { '2019-01-01' }
+    let(:period_end) { '2019-12-31' }
+    let(:patient_ids) { 'patient-1,patient-2' }
+
+    it 'passes with correct FHIR Parameters resource returned' do
+      measure_urls = [measure_url, additional_measure_url]
+      patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+      parameters_request = create_parameters_request(
+        measure_urls:, period_start:, period_end:, patient_id_list:
+      )
+      parameters_response = FHIR::Parameters.new(
+        parameter: patient_id_list.map do
+          FHIR::Parameters::Parameter.new(
+            name: 'return',
+            resource: FHIR::Bundle.new(
+              type: 'transaction',
+              entry: measure_urls.map do |measure_url|
+                {
+                  resource: FHIR::MeasureReport.new(
+                    status: 'complete',
+                    type: 'data-collection',
+                    measure: measure_url,
+                    period: { start: period_start, end: period_end }
+                  )
+                }
+              end
+            )
+          )
+        end
+      )
+
+      stub_request(:post, "#{url}/Measure/$collect-data").with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_ids:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if result has incorrect number of measure reports' do
+      measure_urls = [measure_url, additional_measure_url]
+      patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+      parameters_request = create_parameters_request(
+        measure_urls:, period_start:, period_end:, patient_id_list:
+      )
+      parameters_response = FHIR::Parameters.new(
+        parameter: patient_id_list.map do
+          FHIR::Parameters::Parameter.new(
+            name: 'return',
+            resource: FHIR::Bundle.new(
+              type: 'transaction',
+              entry: [
+                {
+                  resource: FHIR::MeasureReport.new(
+                    status: 'complete',
+                    type: 'data-collection',
+                    measure: measure_url,
+                    period: { start: period_start, end: period_end }
+                  )
+                }
+              ]
+            )
+          )
+        end
+      )
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_ids:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if result has incorrect number of bundles' do
+      measure_urls = [measure_url, additional_measure_url]
+      patient_id_list = patient_ids.split(',').map(&:strip).reject(&:empty?)
+      parameters_request = create_parameters_request(
+        measure_urls:, period_start:, period_end:, patient_id_list:
+      )
+      parameters_response = create_parameters_response(measure_urls:)
+
+      stub_request(
+        :post, "#{url}/Measure/$collect-data"
+      ).with(
+        body: parameters_request.to_json,
+        headers: {
+          'Content-Type' => 'application/fhir+json',
+          'Origin' => 'http://example.com/fhir',
+          'Referrer' => 'http://example.com/fhir'
+        }
+      ).to_return(status: 200, body: parameters_response.to_json, headers: {})
+
+      result = run(test, url:, measure_url:, additional_measure_url:, period_start:, period_end:, patient_ids:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
   describe 'GET Measure/$collect-data missing periodEnd' do
     let(:test) { test_by_id(group, 'collect-data-missing-period-end-get-fail') }
     let(:measure_url) { 'http://example.com/Measure/measure-EXM130' }

--- a/spec/utils/collect_data_spec_utils.rb
+++ b/spec/utils/collect_data_spec_utils.rb
@@ -5,7 +5,8 @@ require 'json'
 module DEQMTestKit
   # Helpers shared by $collect-data specs
   module CollectDataSpecUtils
-    def create_parameters_response(measure_urls:)
+    # rubocop:disable Metrics/MethodLength
+    def create_parameters_response(measure_urls:, patient_ids: nil)
       measure_reports = measure_urls.map do |url|
         FHIR::MeasureReport.new(
           status: 'complete', type: 'data-collection',
@@ -13,36 +14,47 @@ module DEQMTestKit
           period: { start: '2019-01-01', end: '2019-12-31' }
         )
       end
-      bundle = FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
 
-      FHIR::Parameters.new(parameter: { name: 'return', resource: bundle })
+      bundles = (patient_ids || [nil]).map do
+        FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
+      end
+
+      FHIR::Parameters.new(
+        parameter: bundles.map { |bundle| FHIR::Parameters::Parameter.new(name: 'return', resource: bundle) }
+      )
     end
+    # rubocop:enable Metrics/MethodLength
 
-    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
-    def create_parameters_request(measure_urls:, period_start:, period_end:, patient_id: nil, patient_id_list: nil,
-                                  data_endpoint: nil)
-      parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
-      parameters << { name: 'subject', valueString: "Patient/#{patient_id}" } if patient_id
-      if patient_id_list
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def create_parameters_request(options)
+      parameters = options[:measure_urls].map do |measure_url|
+        { name: 'measureUrl', valueCanonical: measure_url }
+      end
+      parameters << { name: 'subject', valueString: "Patient/#{options[:patient_id]}" } if options[:patient_id]
+      if options[:patient_id_list]
         parameters << {
           name: 'subjectGroup',
           resource: {
             resourceType: 'Group',
             id: 'test-group-subjectGroup',
-            member: patient_id_list.map { |group_patient_id| { entity: { reference: "Patient/#{group_patient_id}" } } }
+            type: 'person',
+            actual: true,
+            member: options[:patient_id_list].map do |patient_id|
+              { entity: { reference: "Patient/#{patient_id}" } }
+            end
           }
         }
       end
-      parameters << { name: 'periodStart', valueDate: period_start }
-      parameters << { name: 'periodEnd', valueDate: period_end }
-      parameters << { name: 'dataEndpoint', resource: JSON.parse(data_endpoint) } if data_endpoint
+      parameters << { name: 'periodStart', valueDate: options[:period_start] }
+      parameters << { name: 'periodEnd', valueDate: options[:period_end] }
+      parameters << { name: 'dataEndpoint', resource: JSON.parse(options[:data_endpoint]) } if options[:data_endpoint]
 
       {
         resourceType: 'Parameters',
         parameter: parameters
       }
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def run(runnable, inputs = {})
       test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)

--- a/spec/utils/collect_data_spec_utils.rb
+++ b/spec/utils/collect_data_spec_utils.rb
@@ -6,7 +6,7 @@ module DEQMTestKit
   # Helpers shared by $collect-data specs
   module CollectDataSpecUtils
     # rubocop:disable Metrics/MethodLength
-    def create_parameters_response(measure_urls:, patient_ids: nil)
+    def create_parameters_response(measure_urls:, bundle_count: 1)
       measure_reports = measure_urls.map do |url|
         FHIR::MeasureReport.new(
           status: 'complete', type: 'data-collection',
@@ -15,7 +15,7 @@ module DEQMTestKit
         )
       end
 
-      bundles = (patient_ids || [nil]).map do
+      bundles = bundle_count.times.map do
         FHIR::Bundle.new(type: 'transaction', entry: measure_reports.map { |mr| { resource: mr } })
       end
 

--- a/spec/utils/collect_data_spec_utils.rb
+++ b/spec/utils/collect_data_spec_utils.rb
@@ -18,9 +18,21 @@ module DEQMTestKit
       FHIR::Parameters.new(parameter: { name: 'return', resource: bundle })
     end
 
-    def create_parameters_request(measure_urls:, period_start:, period_end:, patient_id: nil, data_endpoint: nil)
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def create_parameters_request(measure_urls:, period_start:, period_end:, patient_id: nil, patient_id_list: nil,
+                                  data_endpoint: nil)
       parameters = measure_urls.map { |measure_url| { name: 'measureUrl', valueCanonical: measure_url } }
       parameters << { name: 'subject', valueString: "Patient/#{patient_id}" } if patient_id
+      if patient_id_list
+        parameters << {
+          name: 'subjectGroup',
+          resource: {
+            resourceType: 'Group',
+            id: 'test-group-subjectGroup',
+            member: patient_id_list.map { |group_patient_id| { entity: { reference: "Patient/#{group_patient_id}" } } }
+          }
+        }
+      end
       parameters << { name: 'periodStart', valueDate: period_start }
       parameters << { name: 'periodEnd', valueDate: period_end }
       parameters << { name: 'dataEndpoint', resource: JSON.parse(data_endpoint) } if data_endpoint
@@ -30,6 +42,7 @@ module DEQMTestKit
         parameter: parameters
       }
     end
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
     def run(runnable, inputs = {})
       test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)


### PR DESCRIPTION
# Summary
This PR adds two $collect-data operation tests, specifically for a POST to $collect-data with the subjectGroup parameter.
## New behavior
- POST Measure/$collect-data with 1 measureUrl, periodStart, periodEnd, subjectGroup in the request body returns 200 with FHIR Parameters resource with X number of Bundles (how many patients are in the subjectGroup passed in) each with 1 Measure Report.
- POST Measure/$colelct-data with 2 measureUrls, periodStart, periodEnd, subjectGroup in the request body returns 200 with FHIR Parameters resource with X number of Bundles (how many patients are in the subjectGroup passed in) each with 2 Measure Reports.

## Code changes
`lib/deqm-test-kit/collect_data_v1.rb` - Added 2 tests as described above.
`lib/utils/collect_data_utils.rb` - updated `collect_data_body` to take a list of patients (`patient_id_list`)
`spec/deqm_test_kit/v1.0.0/collect_data_spec.rb` - Added corresponding spec pass and fail tests.
`spec/utils/collect_data_spec_utils.rb` - updated `create_parameters_request` to take a list of patients (`patient_id_list`) 

# Testing guidance
In deqm-test-kit:
`bundle exec rubocop`
`bundle exec rspec `
`ASYNC_JOBS=false bundle exec puma`

In bulk-export-server:
`npm run start`

For the inputs, select CMS506FHIRSafeUseofOpioids, CMS1017FHIRHHFI as the measures, http://localhost:3001 as the url, enter f6dafa7e-15a9-4fec-baea-59d43201caf8 as Patient ID, and f6dafa7e-15a9-4fec-baea-59d43201caf8, c58acff5-248b-49c9-b18d-69e4a84a08d9 in the Patient IDs list